### PR TITLE
Changed response to include full objects instead of ids

### DIFF
--- a/src/Entities/Core/Address.php
+++ b/src/Entities/Core/Address.php
@@ -61,7 +61,7 @@ class Address implements JsonSerializable, Searchable
             'line2' => $this->getLine2(),
             'postalCode' => $this->getPostalCode(),
             'city' => $this->getCity(),
-            'countryId' => ($this->getCountry())->getId()
+            'country' => $this->getCountry()
         ];
     }
 

--- a/src/Entities/Core/Address.php
+++ b/src/Entities/Core/Address.php
@@ -147,22 +147,6 @@ class Address implements JsonSerializable, Searchable
     /**
      * @return mixed
      */
-    public function getCountryId()
-    {
-        return $this->country_id;
-    }
-
-    /**
-     * @param mixed $country_id
-     */
-    public function setCountryId($country_id): void
-    {
-        $this->country_id = $country_id;
-    }
-
-    /**
-     * @return mixed
-     */
     public function getCountry()
     {
         return $this->country;

--- a/src/Entities/Core/Department.php
+++ b/src/Entities/Core/Department.php
@@ -48,7 +48,6 @@ class Department implements JsonSerializable, Searchable
             'id' => $this->getId(),
             'label' => $this->getLabel(),
             'name' => $this->getName()
-
         ];
     }
 

--- a/src/Entities/Core/Member.php
+++ b/src/Entities/Core/Member.php
@@ -61,16 +61,7 @@ class Member implements JsonSerializable
      *      )
      */
     protected $positions;
-
-    /**
-     * Member constructor.
-     * @param $firstName
-     * @param $lastName
-     * @param $birthday
-     * @param $telephone
-     * @param $email
-     * @param $schoolYear
-     */
+    
     public function __construct($firstName, $lastName, $birthday, $telephone, $email, $schoolYear, $gender, $department, $positions)
     {
         $this->firstName = $firstName;
@@ -91,14 +82,14 @@ class Member implements JsonSerializable
             'username' => $this->getUser()->getUsername(),
             'firstName' => $this->getFirstName(),
             'lastName' => $this->getLastName(),
-            'genderId' => $this->getGender()->getId(),
+            'gender' => $this->getGender(),
             'email' => $this->getEmail(),
             'birthday' => $this->getBirthday()->format('Y-m-d'),
-            'departmentId' => $this->getDepartment()->getId(),
+            'department' => $this->getDepartment(),
             'schoolYear' => $this->getSchoolYear(),
             'telephone' => $this->getTelephone(),
-            'addressId' => $this->getAddress()->getId(),
-            'positionIds' => $this->getPositionIds()
+            'address' => $this->getAddress(),
+            'positions' => $this->getPositionsArray()
         ];
     }
 
@@ -291,25 +282,14 @@ class Member implements JsonSerializable
     /**
      * @return array
      */
-    public function getPositionIds()
+    public function getPositionsArray()
     {
-        $positionIds = [];
+        $positions = [];
         foreach ($this->getPositions() as $position)
         {
-            $positionIds[] = $position->getId();
+            $positions[] = $position;
         }
 
-        return $positionIds;
+        return $positions;
     }
-
-    public function addPosition($position): void
-    {
-        $this->positions[] = $position;
-    }
-
-    public function deleteAllPositions()
-    {
-        $this->positions = new ArrayCollection();
-    }
-
 }

--- a/src/Entities/Core/Pole.php
+++ b/src/Entities/Core/Pole.php
@@ -28,6 +28,13 @@ class Pole implements JsonSerializable, Searchable
     /** @Column(type="string", length=64) */
     protected $label;
 
+    public function __construct(int $id, string $name, string $label)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->label = $label;
+    }
+
     public function jsonSerialize()
     {
         return [

--- a/src/Entities/Core/Position.php
+++ b/src/Entities/Core/Position.php
@@ -1,14 +1,16 @@
 <?php
 
 namespace Keros\Entities\Core;
+
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use JsonSerializable;
 use Keros\Tools\Searchable;
-use phpDocumentor\Reflection\Types\Array_;
 
 /**
  * @Entity
@@ -43,24 +45,20 @@ class Position implements JsonSerializable, Searchable
 
     public function jsonSerialize()
     {
-        $serializePosition = array(
+        return [
             'id' => $this->getId(),
             'label' => $this->getLabel(),
-        );
-
-        if ($this->getPole() == null)
-            $serializePosition["poleId"] = null;
-        else
-            $serializePosition["poleId"] = $this->getPole()->getId();
-
-        return $serializePosition;
+            'pole' => $this->getPole()
+        ];
     }
 
-    public static function getSearchFields(): array {
+    public static function getSearchFields(): array
+    {
         return ['label'];
     }
 
     // Getters and setters
+
     /**
      * @return mixed
      */

--- a/src/Entities/Core/User.php
+++ b/src/Entities/Core/User.php
@@ -8,7 +8,7 @@ use Keros\Tools\Searchable;
  * @Entity
  * @Table(name="core_user")
  */
-class User implements JsonSerializable, Searchable
+class User implements Searchable
 {
     /**
      * @Id
@@ -52,19 +52,6 @@ class User implements JsonSerializable, Searchable
         $this->createdAt = $createdAt;
         $this->disabled = $disabled;
         $this->expiresAt = $expiresAt;
-    }
-
-    public function jsonSerialize()
-    {
-        return [
-            'id' => $this->getId(),
-            'username' => $this->getUsername(),
-            'password' => $this->getPassword(),
-            'lastConnectedAt' => $this->getLastConnectedAt(),
-            'createdAt' => $this->getCreatedAt(),
-            'disabled' => $this->getDisabled(),
-            'expiresAt' => $this->getExpiresAt(),
-        ];
     }
 
     public static function getSearchFields(): array {

--- a/src/Entities/Ua/Firm.php
+++ b/src/Entities/Ua/Firm.php
@@ -51,8 +51,8 @@ class Firm implements JsonSerializable, Searchable
             'id' => $this->getId(),
             'siret' => $this->getSiret(),
             'name' => $this->getName(),
-            'addressId' => ($this->getAddress())->getId(),
-            'typeId' => ($this->getType())->getId(),
+            'address' => $this->getAddress(),
+            'type' => $this->getType(),
         ];
     }
 

--- a/tests/Core/AddressIntegrationTest.php
+++ b/tests/Core/AddressIntegrationTest.php
@@ -6,7 +6,7 @@ use KerosTest\AppTestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
 
-class PoleIntegrationTest extends AppTestCase
+class AddressIntegrationTest extends AppTestCase
 {
     public function testGetAllAddressesShouldReturn200()
     {
@@ -26,7 +26,7 @@ class PoleIntegrationTest extends AppTestCase
         $this->assertNotNull(strlen($body->content[0]->line1));
         $this->assertNotNull(strlen($body->content[0]->line2));
         $this->assertNotNull(strlen($body->content[0]->postalCode));
-        $this->assertNotNull(strlen($body->content[0]->countryId));
+        $this->assertNotNull(strlen($body->content[0]->country->label));
     }
 
     public function testGetAddressShouldReturn200()
@@ -47,7 +47,7 @@ class PoleIntegrationTest extends AppTestCase
         $this->assertSame(null, $body->line2);
         $this->assertSame(69100, $body->postalCode);
         $this->assertSame("lyon", $body->city);
-        $this->assertSame(1, $body->countryId);
+        $this->assertSame(1, $body->country->id);
     }
 
     public function testGetAddressShouldReturn404()

--- a/tests/Core/AddressTest.php
+++ b/tests/Core/AddressTest.php
@@ -7,7 +7,7 @@ use Keros\Entities\Core\Country;
 use PHPUnit\Framework\TestCase;
 
 
-final class AddressTest extends TestCase
+class AddressTest extends TestCase
 {
     public function testNewAddressShouldBeInstanceOfAddress()
     {

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -26,10 +26,10 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertNotNull(strlen($body->content[0]->username));
         $this->assertNotNull(strlen($body->content[0]->firstName));
         $this->assertNotNull(strlen($body->content[0]->lastName));
-        $this->assertNotNull(strlen($body->content[0]->genderId));
+        $this->assertNotNull(strlen($body->content[0]->gender->id));
         $this->assertNotNull(strlen($body->content[0]->email));
         $this->assertNotNull(strlen($body->content[0]->birthday));
-        $this->assertNotNull(strlen($body->content[0]->addressId));
+        $this->assertNotNull(strlen($body->content[0]->address->id));
 
     }
 
@@ -48,13 +48,13 @@ class MemberIntegrationTest extends AppTestCase
 
         $body = json_decode($response->getBody());
         $this->assertSame(1, $body->id);
-        $this->assertSame(1, $body->genderId);
+        $this->assertSame(1, $body->gender->id);
         $this->assertSame("Conor", $body->firstName);
         $this->assertSame("Breeze", $body->lastName);
         $this->assertSame("1975-12-25", $body->birthday);
         $this->assertSame("+332541254", $body->telephone);
         $this->assertSame("fake.mail@fake.com", $body->email);
-        $this->assertSame(2, $body->addressId);
+        $this->assertSame(2, $body->address->id);
     }
 
     public function testGetMemberShouldReturn404()
@@ -113,15 +113,15 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertNotNull($body->id);
         $this->assertSame("username", $body->username);
         $this->assertSame("lastname", $body->lastName);
-        $this->assertSame(1, $body->genderId);
+        $this->assertSame(1, $body->gender->id);
         $this->assertSame("fakeEmail@gmail.com", $body->email);
         $this->assertSame("1975-12-01", $body->birthday);
-        $this->assertSame(1, $body->departmentId);
+        $this->assertSame(1, $body->department->id);
         $this->assertSame(1, $body->schoolYear);
         $this->assertSame("0033675385495", $body->telephone);
-        $this->assertNotNull($body->addressId);
-        $this->assertContains(1, $body->positionIds);
-        $this->assertContains(2, $body->positionIds);
+        $this->assertNotNull($body->address->id);
+        $this->assertSame(1, $body->positions[0]->id);
+        $this->assertSame(2, $body->positions[1]->id);
     }
     public function testPutMemberShouldReturn200()
     {
@@ -168,15 +168,15 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertSame("username", $body->username);
         $this->assertSame("firstName", $body->firstName);
         $this->assertSame("lastName", $body->lastName);
-        $this->assertSame(1, $body->genderId);
+        $this->assertSame(1, $body->gender->id);
         $this->assertSame("fakeEmail@gmail.com", $body->email);
         $this->assertSame("1975-12-01", $body->birthday);
-        $this->assertSame(1, $body->departmentId);
+        $this->assertSame(1, $body->department->id);
         $this->assertSame(1, $body->schoolYear);
         $this->assertSame("0033675385495", $body->telephone);
-        $this->assertNotNull($body->addressId);
-        $this->assertContains(1, $body->positionIds);
-        $this->assertContains(3, $body->positionIds);
+        $this->assertNotNull($body->address->id);
+        $this->assertSame(1, $body->positions[0]->id);
+        $this->assertSame(3, $body->positions[1]->id);
     }
 
     public function testPutMemberEmptyBodyShouldReturn200()

--- a/tests/Core/MemberTest.php
+++ b/tests/Core/MemberTest.php
@@ -10,7 +10,7 @@ use Keros\Entities\Core\Position;
 use PHPUnit\Framework\TestCase;
 
 
-final class MemberTest extends TestCase
+class MemberTest extends TestCase
 {
     public function testNewMemberShouldBeInstanceOfMember()
     {

--- a/tests/Core/PositionIntegrationTest.php
+++ b/tests/Core/PositionIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace KerosTest\position;
 
+use Keros\Entities\Core\Pole;
 use KerosTest\AppTestCase;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -41,7 +42,7 @@ class PositionIntegrationTest extends AppTestCase
         $body = json_decode($response->getBody());
         $this->assertSame(1, $body->id);
         $this->assertSame("Ancien membre", $body->label);
-        $this->assertNull($body->poleId);
+        $this->assertNull($body->pole);
     }
 
     public function testGetPositionWithPoleShouldReturn200()
@@ -59,7 +60,7 @@ class PositionIntegrationTest extends AppTestCase
         $body = json_decode($response->getBody());
         $this->assertSame(3, $body->id);
         $this->assertSame("Chargé d'affaires", $body->label);
-        $this->assertSame(10, $body->poleId);
+        $this->assertEquals(10, $body->pole->id);
     }
 
     public function testGetPositionShouldReturn404()

--- a/tests/Core/UserTest.php
+++ b/tests/Core/UserTest.php
@@ -5,7 +5,7 @@ namespace KerosTest\Core;
 use Keros\Entities\Core\User;
 use PHPUnit\Framework\TestCase;
 
-final class UserTest extends TestCase
+class UserTest extends TestCase
 {
     public function testNewUserShouldBeInstanceOfUser()
     {

--- a/tests/Core/ValidatorTest.php
+++ b/tests/Core/ValidatorTest.php
@@ -6,7 +6,7 @@ use Keros\Error\KerosException;
 use Keros\Tools\Validator;
 use PHPUnit\Framework\TestCase;
 
-final class ValidatorTest extends TestCase
+class ValidatorTest extends TestCase
 {
     public function testValidEmailShouldReturnSame(): void
     {


### PR DESCRIPTION
C'est pour aider le front que j'ai fait ça - j'ai déjà modifié la doc.

- "Serializable" enlevé de user comme on ne le retournera jamais (sécurité)
- les tests ne passaient plus donc ils sont updates aussi.
- virer de la doc non rempli
- "final" qui y était parfois et d'autres fois non enlevé