### PR TITLE
quick fix study required fields

### DIFF
--- a/src/Services/Ua/StudyService.php
+++ b/src/Services/Ua/StudyService.php
@@ -94,19 +94,13 @@ class StudyService
         $name = Validator::requiredString($fields["name"]);
         $description = Validator::optionalString(isset($fields["description"]) ? $fields["description"] : null);
 
-        $fieldId = Validator::optionalId(isset($fields["fieldId"]) ? $fields["fieldId"] : null);
-        if ($fieldId != null)
-            $field = $this->fieldService->getOne($fieldId);
-        else
-            $field = null;
-
-        $statusId = Validator::optionalId(isset($fields["statusId"]) ? $field["statusId"] : null);
+        $statusId = Validator::optionalId(isset($fields["statusId"]) ? $fields["statusId"] : null);
         if ($statusId != null)
             $status = $this->statusService->getOne($statusId);
         else
             $status = null;
 
-        $firmId = Validator::optionalId(isset($fields["firmId"]) ? $field["firmId"] : null);
+        $firmId = Validator::optionalId(isset($fields["firmId"]) ? $fields["firmId"] : null);
         if ($firmId != null)
             $firm = $this->firmService->getOne($firmId);
         else
@@ -155,6 +149,12 @@ class StudyService
         }
 
         $confidential = Validator::optionalBool(isset($fields["confidential"]) ? $fields["confidential"] : null);
+
+        $fieldId = Validator::optionalId(isset($fields["fieldId"]) ? $fields["fieldId"] : null);
+        if ($fieldId != null)
+            $field = $this->fieldService->getOne($fieldId);
+        else
+            $field = null;
 
         $study = new Study($name, $description, $field, $status, $firm, $contacts, $leaders, $consultants, $qualityManagers, $confidential);
 
@@ -226,12 +226,6 @@ class StudyService
         $name = Validator::requiredString($fields["name"]);
         $description = Validator::optionalString(isset($fields["description"]) ? $fields["description"] : null);
 
-        $fieldId = Validator::optionalId(isset($fields["fieldId"]) ? $fields["fieldId"] : null);
-        if ($fieldId != null)
-            $field = $this->fieldService->getOne($fieldId);
-        else
-            $field = null;
-
         $statusId = Validator::optionalId(isset($fields["statusId"]) ? $fields["statusId"] : null);
         if ($statusId != null)
             $status = $this->statusService->getOne($statusId);
@@ -286,6 +280,11 @@ class StudyService
             $provenance = $this->provenanceService->getOne($provenanceId);
         }
 
+        $fieldId = Validator::optionalId(isset($fields["fieldId"]) ? $fields["fieldId"] : null);
+        if ($fieldId != null)
+            $field = $this->fieldService->getOne($fieldId);
+        else
+            $field = null;
 
         $confidential = Validator::optionalBool(isset($fields["confidential"]) ? $fields["confidential"] : null);
 

--- a/tests/Ua/StudyIntegrationTest.php
+++ b/tests/Ua/StudyIntegrationTest.php
@@ -173,6 +173,36 @@ class StudyIntegrationTest extends AppTestCase
         $this->assertSame("Facebook", $body->name);
     }
 
+    public function testPostStudyShouldReturn201()
+    {
+        $post_body = array(
+            "name"=>"Twitter",
+            "description"=>"C est le feu",
+            "fieldId"=>1,
+            "provenanceId"=>1,
+            "statusId"=>1,
+            "firmId"=>1,
+            "contactIds"=>array(),
+            "leaderIds"=>array(),
+            "consultantIds"=>array(),
+            "qualityManagerIds"=>array(),
+            "confidential"=>true,
+        );
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/api/v1/ua/study',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withParsedBody($post_body);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(201, $response->getStatusCode());
+        $body = json_decode($response->getBody());
+        $this->assertSame(3, $body->id);
+        $this->assertSame("Twitter", $body->name);
+        $this->assertSame("C est le feu", $body->description);
+    }
+
     public function testPutStudyShouldReturn200()
     {
 


### PR DESCRIPTION
Dommage de faire une PR pour ça, mais il manquait 2 's' (field et non fields). Il manquait un test, ce qui explique que ça a passé les tests mais que ça ne fonctionnait pas avec le front. Le tout est résolut.