### PR TITLE
correct member pagination

### DIFF
--- a/src/Controllers/Core/MemberController.php
+++ b/src/Controllers/Core/MemberController.php
@@ -86,7 +86,9 @@ class MemberController
         $queryParams = $request->getQueryParams();
         $requestParameters = new RequestParameters($queryParams, Member::getSearchFields());
 
-        $page = $this->memberService->getPage($requestParameters, $queryParams);
+        $members = $this->memberService->getPage($requestParameters, $queryParams);
+
+        $page = new Page($members, $requestParameters, count($members));
 
         return $response->withJson($page, 200);
     }

--- a/src/Controllers/Core/MemberController.php
+++ b/src/Controllers/Core/MemberController.php
@@ -4,7 +4,6 @@ namespace Keros\Controllers\Core;
 
 use Doctrine\ORM\EntityManager;
 use Keros\Entities\core\Member;
-use Keros\Entities\Core\MemberPosition;
 use Keros\Entities\Core\Page;
 use Keros\Entities\Core\RequestParameters;
 use Keros\Services\Core\MemberService;

--- a/src/DataServices/Core/MemberDataService.php
+++ b/src/DataServices/Core/MemberDataService.php
@@ -74,7 +74,7 @@ class MemberDataService
     /**
      * @param RequestParameters $requestParameters
      * @param $queryParams
-     * @return Page
+     * @return array
      * @throws KerosException
      */
     public function getPage(RequestParameters $requestParameters, array $queryParams)
@@ -135,8 +135,8 @@ class MemberDataService
 
             $order = $requestParameters->getParameters()['order'];
             $orderBy = $requestParameters->getParameters()['orderBy'];
-            $pageSize = $requestParameters->getParameters()['pageSize'];
-            $firstResult = $pageSize * $requestParameters->getParameters()['pageNumber'];
+            //$pageSize = $requestParameters->getParameters()['pageSize'];
+            //$firstResult = $pageSize * $requestParameters->getParameters()['pageNumber'];
 
             if (!empty($whereStatement)) {
                 $this->queryBuilder
@@ -147,15 +147,17 @@ class MemberDataService
             if (isset($orderBy)) {
                 $this->queryBuilder->orderBy($orderBy, $order);
             }
-
+/*
             $this->queryBuilder
                 ->setFirstResult($firstResult)
                 ->setMaxResults($pageSize);
+*/
+            $query = $this->queryBuilder->getQuery();//sql ok ici
+    //        $paginator = new Paginator($query, $fetchJoinCollection = false);
+      //      $this->logger->debug(count($paginator->getIterator()->getArrayCopy()));
+  //          $page = new Page($query->execute(), $requestParameters, count($paginator));
 
-            $query = $this->queryBuilder->getQuery();
-            $paginator = new Paginator($query, $fetchJoinCollection = true);
-
-            return new Page($query->execute(), $requestParameters, count($paginator));
+            return $query->execute();
 
         } catch (Exception $e) {
             $msg = "Error finding page of members : " . $e->getMessage();

--- a/src/DataServices/Core/MemberDataService.php
+++ b/src/DataServices/Core/MemberDataService.php
@@ -3,15 +3,12 @@
 namespace Keros\DataServices\Core;
 
 
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 use Exception;
 use Keros\Entities\Core\Member;
 use Keros\Entities\Core\MemberPosition;
-use Keros\Entities\Core\Page;
 use Keros\Entities\Core\Pole;
 use Keros\Entities\Core\Position;
 use Keros\Entities\Core\RequestParameters;
@@ -135,8 +132,6 @@ class MemberDataService
 
             $order = $requestParameters->getParameters()['order'];
             $orderBy = $requestParameters->getParameters()['orderBy'];
-            //$pageSize = $requestParameters->getParameters()['pageSize'];
-            //$firstResult = $pageSize * $requestParameters->getParameters()['pageNumber'];
 
             if (!empty($whereStatement)) {
                 $this->queryBuilder
@@ -147,18 +142,9 @@ class MemberDataService
             if (isset($orderBy)) {
                 $this->queryBuilder->orderBy($orderBy, $order);
             }
-/*
-            $this->queryBuilder
-                ->setFirstResult($firstResult)
-                ->setMaxResults($pageSize);
-*/
+
             $query = $this->queryBuilder->getQuery();//sql ok ici
-    //        $paginator = new Paginator($query, $fetchJoinCollection = false);
-      //      $this->logger->debug(count($paginator->getIterator()->getArrayCopy()));
-  //          $page = new Page($query->execute(), $requestParameters, count($paginator));
-
             return $query->execute();
-
         } catch (Exception $e) {
             $msg = "Error finding page of members : " . $e->getMessage();
             $this->logger->error($msg);

--- a/src/Services/Core/MemberService.php
+++ b/src/Services/Core/MemberService.php
@@ -6,7 +6,6 @@ namespace Keros\Services\Core;
 use Keros\DataServices\Core\MemberDataService;
 use Keros\DataServices\Core\TicketDataService;
 use Keros\Entities\Core\Member;
-use Keros\Entities\Core\Page;
 use Keros\Entities\Core\RequestParameters;
 use Keros\Error\KerosException;
 use Keros\Tools\Validator;

--- a/src/Services/Core/MemberService.php
+++ b/src/Services/Core/MemberService.php
@@ -119,13 +119,18 @@ class MemberService
         return $member;
     }
 
-    public function getPage(RequestParameters $requestParameters, array $queryParams): Page
+    public function getPage(RequestParameters $requestParameters, array $queryParams): array
     {
         if (isset($queryParams['year']) && $queryParams['year'] == 'latest') {
             $queryParams['year'] = $this->memberPositionService->getLatestYear();
         }
 
-        return $this->memberDataService->getPage($requestParameters, $queryParams);
+        $members = $this->memberDataService->getPage($requestParameters, $queryParams);
+        $pageSize = $requestParameters->getParameters()['pageSize'];
+        $firstResult = $pageSize * $requestParameters->getParameters()['pageNumber'];
+        $members = array_slice($members, $firstResult, $pageSize);
+
+        return $members;
     }
 
     public function getSome(array $ids): array

--- a/src/Tools/Database/kerosData.sql
+++ b/src/Tools/Database/kerosData.sql
@@ -2,13 +2,35 @@ SET AUTOCOMMIT = 0;
 SET FOREIGN_KEY_CHECKS = 0;
 SET UNIQUE_CHECKS = 0;
 
-/* Passwords are, in order : hunter11 - hunter12 - hunter13 */
+/* Passwords are on the right */
 TRUNCATE TABLE core_user;
 INSERT INTO core_user (id, username, password, expiresAt) VALUES
-  (1, 'username', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')),
-  (2, 'mcool', '$2y$10$fWnWMRQKKWInygzk.FNIP.BsnTp8e8XvDwj5YdGgVuIFXsz/XvVgm' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')),
-  (3, 'lswollo', '$2y$10$9R4lfhp18.iVzsP8amDL5e7eumi48DmPPkoa5YLAm/thAZWIHaOtW' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')),
-  (4, 'qualqual', '$2y$10$9R4lfhp18.iVzsP8amDL5e7eumi48DmPPkoa5YLAm/thAZWIHaOtW' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r'));
+  (1, 'username', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (2, 'mcool', '$2y$10$fWnWMRQKKWInygzk.FNIP.BsnTp8e8XvDwj5YdGgVuIFXsz/XvVgm' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #hunter11
+  (3, 'lswollo', '$2y$10$9R4lfhp18.iVzsP8amDL5e7eumi48DmPPkoa5YLAm/thAZWIHaOtW' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #hunter12
+  (4, 'qualqual', '$2y$10$9R4lfhp18.iVzsP8amDL5e7eumi48DmPPkoa5YLAm/thAZWIHaOtW' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #hunter13
+  (5, 'user5', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (6, 'user6', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (7, 'user7', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (8, 'user8', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (9, 'user9', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (10, 'user10', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (11, 'user11', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (12, 'user12', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (13, 'user13', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (14, 'user14', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (15, 'user15', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (16, 'user16', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (17, 'user17', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (18, 'user18', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (19, 'user19', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (20, 'user20', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (21, 'user21', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (22, 'user22', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (23, 'user23', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (24, 'user24', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (25, 'user25', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')), #password
+  (26, 'user26', '$2y$10$CMdJgBHbdymIM5/WUuz8guvjvSA2dxgDQKAQkaiOD8aMF0sKc4GhG' , STR_TO_DATE('5/15/2022 8:06:26 AM', '%c/%e/%Y %r')); #password
 
 TRUNCATE TABLE core_address;
 INSERT INTO core_address (id, line1, line2, postalCode, city, countryId) VALUES
@@ -17,7 +39,29 @@ INSERT INTO core_address (id, line1, line2, postalCode, city, countryId) VALUES
   (3, '11 ETIC street', 'bat. b', '91002', 'paris', 1), # member 3
   (4, '11 Backbeat street', 'bat. a', '91004', 'djibouti', 3), # firm 1
   (5, '17 Watcha ave', 'porte 5', '674A4', 'Leicester', 40), # firm 2
-  (6, '17 Beat', 'Meat', '674A4', 'Paris', 40); # member 4
+  (6, 'rue test 6', 'Meat', '674A4', 'Paris', 40), # member 4
+  (7, 'rue test 7', 'Meat', '674A4', 'Paris', 40), # member 5
+  (8, 'rue test 8', 'Meat', '674A4', 'Paris', 40), # member 6
+  (9, 'rue test 9', 'Meat', '674A4', 'Paris', 40), # member 7
+  (10, 'rue test 10', 'Meat', '674A4', 'Paris', 40), # member 8
+  (11, 'rue test 11', 'Meat', '674A4', 'Paris', 40), # member 9
+  (12, 'rue test 12', 'Meat', '674A4', 'Paris', 40), # member 10
+  (13, 'rue test 13', 'Meat', '674A4', 'Paris', 40), # member 11
+  (14, 'rue test 14', 'Meat', '674A4', 'Paris', 40), # member 12
+  (15, 'rue test 15', 'Meat', '674A4', 'Paris', 40), # member 13
+  (16, 'rue test 16', 'Meat', '674A4', 'Paris', 40), # member 14
+  (17, 'rue test 17', 'Meat', '674A4', 'Paris', 40), # member 15
+  (18, 'rue test 18', 'Meat', '674A4', 'Paris', 40), # member 16
+  (19, 'rue test 19', 'Meat', '674A4', 'Paris', 40), # member 17
+  (20, 'rue test 20', 'Meat', '674A4', 'Paris', 40), # member 18
+  (21, 'rue test 21', 'Meat', '674A4', 'Paris', 40), # member 19
+  (22, 'rue test 22', 'Meat', '674A4', 'Paris', 40), # member 20
+  (23, 'rue test 23', 'Meat', '674A4', 'Paris', 40), # member 21
+  (24, 'rue test 24', 'Meat', '674A4', 'Paris', 40), # member 22
+  (25, 'rue test 25', 'Meat', '674A4', 'Paris', 40), # member 23
+  (26, 'rue test 26', 'Meat', '674A4', 'Paris', 40), # member 24
+  (27, 'rue test 27', 'Meat', '674A4', 'Paris', 40), # member 25
+  (28, 'rue test 28', 'Meat', '674A4', 'Paris', 40); # member 26
 
 TRUNCATE TABLE core_ticket;
 INSERT INTO core_ticket (id, userId, title, message, type, status) VALUES
@@ -28,7 +72,29 @@ INSERT INTO core_member (id, genderId, firstName, lastName, birthday, telephone,
   (1, 1, 'Conor', 'Breeze', STR_TO_DATE('1975-12-25', '%Y-%m-%d'), '+332541254', 'fake.mail@fake.com', 2, 3, 1, 'Google', 'http://picture.png'),
   (2, 1, 'Marah', 'Cool', STR_TO_DATE('1976-10-27', '%Y-%m-%d'), '+332541541', 'fake.mail2@fake.com', 1, 3, 1, 'Amazon', NULL),
   (3, 1, 'Laurence', 'Tainturière', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.mail3@fake.com', 3, 5, 2, NULL, NULL),
-  (4, 3, 'Stéphane', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly@fake.com', 6, 3, 4, NULL, NULL);
+  (4, 3, 'Stéphane4', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly4@fake.com', 6, 3, 4, NULL, NULL),
+  (5, 3, 'Stéphane5', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly5@fake.com', 7, 3, 4, NULL, NULL),
+  (6, 3, 'Stéphane6', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly6@fake.com', 8, 3, 4, NULL, NULL),
+  (7, 3, 'Stéphane7', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly7@fake.com', 9, 3, 4, NULL, NULL),
+  (8, 3, 'Stéphane8', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly8@fake.com', 10, 3, 4, NULL, NULL),
+  (9, 3, 'Stéphane9', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly9@fake.com', 11, 3, 4, NULL, NULL),
+  (10, 3, 'Stéphane10', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly10@fake.com', 12, 3, 4, NULL, NULL),
+  (11, 3, 'Stéphane11', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly11@fake.com', 13, 3, 4, NULL, NULL),
+  (12, 3, 'Stéphane12', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly12@fake.com', 14, 3, 4, NULL, NULL),
+  (13, 3, 'Stéphane13', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly13@fake.com', 15, 3, 4, NULL, NULL),
+  (14, 3, 'Stéphane14', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly14@fake.com', 16, 3, 4, NULL, NULL),
+  (15, 3, 'Stéphane15', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly15@fake.com', 17, 3, 4, NULL, NULL),
+  (16, 3, 'Stéphane16', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly16@fake.com', 18, 3, 4, NULL, NULL),
+  (17, 3, 'Stéphane17', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly17@fake.com', 19, 3, 4, NULL, NULL),
+  (18, 3, 'Stéphane18', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly18@fake.com', 20, 3, 4, NULL, NULL),
+  (19, 3, 'Stéphane19', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly19@fake.com', 21, 3, 4, NULL, NULL),
+  (20, 3, 'Stéphane20', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly20@fake.com', 22, 3, 4, NULL, NULL),
+  (21, 3, 'Stéphane21', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly21@fake.com', 23, 3, 4, NULL, NULL),
+  (22, 3, 'Stéphane22', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly22@fake.com', 24, 3, 4, NULL, NULL),
+  (23, 3, 'Stéphane23', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly23@fake.com', 25, 3, 4, NULL, NULL),
+  (24, 3, 'Stéphane24', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly24@fake.com', 26, 3, 4, NULL, NULL),
+  (25, 3, 'Stéphane25', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly25@fake.com', 27, 3, 4, NULL, NULL),
+  (26, 3, 'Stéphane26', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly26@fake.com', 28, 3, 4, NULL, NULL);
 
 TRUNCATE TABLE core_member_position;
 INSERT INTO core_member_position (id, memberId, positionId, isBoard, year) VALUES

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -8,6 +8,32 @@ use Slim\Http\Request;
 
 class MemberIntegrationTest extends AppTestCase
 {
+
+    public function testGetAllMembersPage1ShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/core/member?pageNumber=1',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+        $this->assertEquals(1, count($body->content));
+        $this->assertNotNull(strlen($body->content[0]->id));
+        $this->assertNotNull(strlen($body->content[0]->username));
+        $this->assertNotNull(strlen($body->content[0]->firstName));
+        $this->assertNotNull(strlen($body->content[0]->lastName));
+        $this->assertNotNull(strlen($body->content[0]->gender->id));
+        $this->assertNotNull(strlen($body->content[0]->email));
+        $this->assertNotNull(strlen($body->content[0]->birthday));
+        $this->assertNotNull(strlen($body->content[0]->address->id));
+        $this->assertSame(1, $body->meta->totalItems);
+    }
+
     public function testLikeSearchMemberShouldReturn200()
     {
         $env = Environment::mock([

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -172,7 +172,7 @@ class MemberIntegrationTest extends AppTestCase
     public function testDeleteInvalidMemberShouldReturn404(){
         $env = Environment::mock([
             'REQUEST_METHOD' => 'DELETE',
-            'REQUEST_URI' => '/api/v1/core/member/10',
+            'REQUEST_URI' => '/api/v1/core/member/100000',
         ]);
 
         $req = Request::createFromEnvironment($env);
@@ -196,7 +196,7 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertSame(200, $response->getStatusCode());
 
         $body = json_decode($response->getBody());
-        $this->assertEquals(4, count($body->content));
+        $this->assertEquals(25, count($body->content));
         $this->assertNotNull(strlen($body->content[0]->id));
         $this->assertNotNull(strlen($body->content[0]->username));
         $this->assertNotNull(strlen($body->content[0]->firstName));
@@ -235,7 +235,7 @@ class MemberIntegrationTest extends AppTestCase
     {
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => '/api/v1/core/member/10',
+            'REQUEST_URI' => '/api/v1/core/member/10090909',
         ]);
         $req = Request::createFromEnvironment($env);
         $this->app->getContainer()['request'] = $req;

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -202,7 +202,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         //On vérifie maintenant que le membre a bien été ajouté.
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
-            'REQUEST_URI' => '/api/v1/core/member/5', //On get le dernier membre (max de kerosData.sql + 1)
+            'REQUEST_URI' => '/api/v1/core/member/27', //On get le dernier membre (max de kerosData.sql + 1)
         ]);
         $req = Request::createFromEnvironment($env);
         $this->app->getContainer()['request'] = $req;


### PR DESCRIPTION
Correction de la pagination des membres. 25 lignes étaient bien retournées par la requête, mais certaines concerne le même membre mais à des positions différentes. Ces lignes sont donc réunnient en une seule entité, on perd donc une ligne. ça m'étonne que le `Paginator` ne résolve pas ce soucis ... 🤔 

Cette modification récupère tous les `members` filtrés, et sélectionne ensuite la bonne page. Des avis ? On perd en performance c'est sûr 😕. 
**Ne pas merge maintenant**, il y a des commentaires à enlever et un test à push