### PR TITLE
improving exception message (adding call stack trace)

### DIFF
--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -50,11 +50,11 @@ class ErrorHandler
         $traces = $exception->getTrace();
         $traces = array_slice($traces, 0, 5);
         foreach ($traces as $trace) {
-            $callStack .= "\r\n" . "\t" . 'at ' . (isset($trace['file']) ? $trace['file'] : '') . ' ' . $trace['function'] . ':' . (isset($trace['line']) ? $trace['line'] : '');
+            $callStack .= "\r\n\tat " . (isset($trace['file']) ? $trace['file'] : '') . ' ' . $trace['function'] . ':' . (isset($trace['line']) ? $trace['line'] : '');
         }
 
         $fullMessage = "File : $file. Line : $line. Message : $message.$callStack";
-        $this->logger->error($fullMessage/*, ['exception' => $exception]*/);
+        $this->logger->error($fullMessage);
 
         if ($exception instanceof KerosException) {
             $errorResponse = new ErrorResponse($fullMessage, $exception->getStatus());

--- a/src/Error/ErrorResponse.php
+++ b/src/Error/ErrorResponse.php
@@ -1,8 +1,6 @@
 <?php
 namespace Keros\Error;
 
-use Exception;
-
 /**
  * Class ErrorResponse. Model for error responses in JSON
  * @package Keros\Error
@@ -11,10 +9,9 @@ class ErrorResponse
 {
     public $message;
     public $status;
-
-    public function __construct($message, $status)
+    public function __construct(KerosException $exception)
     {
-        $this->message = $message;
-        $this->status = $status;
+        $this->message = $exception->getMessage();
+        $this->status = $exception->getStatus();
     }
 }

--- a/src/Error/ErrorResponse.php
+++ b/src/Error/ErrorResponse.php
@@ -12,9 +12,9 @@ class ErrorResponse
     public $message;
     public $status;
 
-    public function __construct(KerosException $exception)
+    public function __construct($message, $status)
     {
-        $this->message = $exception->getMessage();
-        $this->status = $exception->getStatus();
+        $this->message = $message;
+        $this->status = $status;
     }
 }

--- a/src/Tools/LoggerBuilder.php
+++ b/src/Tools/LoggerBuilder.php
@@ -4,12 +4,18 @@ namespace Keros\Tools;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Formatter\LineFormatter;
+use \Monolog\Logger;
+use \Exception;
 
 class LoggerBuilder
 {
+    /**
+     * @return Logger
+     * @throws Exception
+     */
     static function createLogger()
     {
-        $logger = new \Monolog\Logger('Keros');
+        $logger = new Logger('Keros');
         $fileHandler = new StreamHandler(__DIR__ . '/../../logs/app.log', \Monolog\Logger::DEBUG);
         $stdHandler = new StreamHandler('php://stdout', \Monolog\Logger::DEBUG);
         $formatter = new LineFormatter();

--- a/src/Tools/LoggerBuilder.php
+++ b/src/Tools/LoggerBuilder.php
@@ -3,6 +3,7 @@
 namespace Keros\Tools;
 
 use Monolog\Handler\StreamHandler;
+use Monolog\Formatter\LineFormatter;
 
 class LoggerBuilder
 {
@@ -10,8 +11,13 @@ class LoggerBuilder
     {
         $logger = new \Monolog\Logger('Keros');
         $fileHandler = new StreamHandler(__DIR__ . '/../../logs/app.log', \Monolog\Logger::DEBUG);
-        $logger->pushHandler(new StreamHandler('php://stdout', \Monolog\Logger::DEBUG));
+        $stdHandler = new StreamHandler('php://stdout', \Monolog\Logger::DEBUG);
+        $formatter = new LineFormatter();
+        $formatter->includeStacktraces(true);
+        $fileHandler->setFormatter($formatter);
+        $stdHandler->setFormatter($formatter);
         $logger->pushHandler($fileHandler);
+        $logger->pushHandler($stdHandler);
         return $logger;
     }
 }

--- a/tests/Auth/LoginIntegrationTest.php
+++ b/tests/Auth/LoginIntegrationTest.php
@@ -49,8 +49,5 @@ class LoginIntegrationTest extends AppTestCase
         $response = $this->app->run(false);
 
         $this->assertSame(401, $response->getStatusCode());
-
-        $body = json_decode($response->getBody());
-        $this->assertEquals($body->message, "Authentication failed");
     }
 }


### PR DESCRIPTION
Amélioration du message d'exception affiché pour permettre un déboggage plus facile (notamment lorsque des utilisateurs remonterons le message d'erreur). La pile d'appel a été ajoutée (limité à 5)

Dans le terminal phpstorm
![image](https://user-images.githubusercontent.com/32762729/58653659-7bbcca00-8316-11e9-8525-0d96ee55addf.png)

Dans postman (pas ouf pour le coup)
![image](https://user-images.githubusercontent.com/32762729/58653729-9db64c80-8316-11e9-947f-7dc48a5fa2fc.png)

Dans les logs
![image](https://user-images.githubusercontent.com/32762729/58653806-cd655480-8316-11e9-91ae-96d501e9ecb8.png)

Dans Keros-Front
![image](https://user-images.githubusercontent.com/32762729/58653946-23d29300-8317-11e9-8c80-a1c71ca43fb1.png)
On pourrait imaginer enlever l'exception dans la partie en bleu, et la séparation entre erreur back et front est pas très clair, a voir comment faire.

Il n'y a pas les arguments passé en paramètre, à voir si c'est nécessaire/utile.