### PR TITLE
fixing search using search key word for member and contact

### DIFF
--- a/src/DataServices/Core/MemberDataService.php
+++ b/src/DataServices/Core/MemberDataService.php
@@ -105,10 +105,10 @@ class MemberDataService
                                 $searchStatement .= ' AND ';
 
                             $searchStatement .=
-                                '(m.firstName = :search' . $i
-                                . ' OR m.lastName = :search' . $i
-                                . ' OR m.company = :search' . $i . ')';
-                            $whereParameters[':search' . $i] = $field;
+                                '(m.firstName like :search' . $i
+                                . ' OR m.lastName like :search' . $i
+                                . ' OR m.company like :search' . $i . ')';
+                            $whereParameters[':search' . $i] = '%' . $field . '%';
                         }
 
                         $whereStatement .= $searchStatement;

--- a/src/DataServices/Ua/ContactDataService.php
+++ b/src/DataServices/Ua/ContactDataService.php
@@ -117,9 +117,9 @@ class ContactDataService
                                 $searchStatement .= ' AND ';
 
                             $searchStatement .=
-                                '(c.firstName = :search' . $i
-                                . ' OR c.lastName = :search' . $i . ')';
-                            $whereParameters[':search' . $i] = $field;
+                                '(c.firstName like :search' . $i
+                                . ' OR c.lastName like :search' . $i . ')';
+                            $whereParameters[':search' . $i] = '%' . $field . '%';
                         }
 
                         $whereStatement .= $searchStatement;

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -503,4 +503,20 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertSame(401, $response->getStatusCode());
     }
 
+    public function testSearchMemberUsingSearchShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/core/member?search=Laur',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode($response->getBody());
+        $this->assertNotNull($body->content);
+        $this->assertSame(1, sizeof($body->content));
+        $this->assertSame(3, $body->content[0]->id);
+    }
+
 }

--- a/tests/Ua/ContactIntegrationTest.php
+++ b/tests/Ua/ContactIntegrationTest.php
@@ -200,4 +200,23 @@ class ContactIntegrationTest extends AppTestCase
         $this->assertSame(204, $response->getStatusCode());
 
     }
+
+    public function testSearchContactUsingSearchShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/ua/contact?search=Lan',
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+        $this->assertNotNull($body->content);
+        $this->assertSame(1, sizeof($body->content));
+        $this->assertSame(1, $body->content[0]->id);
+    }
 }


### PR DESCRIPTION
Permet d'utiliser le query parameter `search` en mode like % % / contain