### PR TITLE
round value to 2 decimal

### DIFF
--- a/src/Entities/Treso/Facture.php
+++ b/src/Entities/Treso/Facture.php
@@ -184,7 +184,8 @@ class Facture implements \JsonSerializable
         ];
     }
 
-    public static function getSearchFields(): array {
+    public static function getSearchFields(): array
+    {
         return ['numero', 'clientName', 'contactName', 'study', 'type'];
     }
 
@@ -193,7 +194,9 @@ class Facture implements \JsonSerializable
      */
     public function getAmountTTC()
     {
-        return $this->amountHT * (($this->taxPercentage / 100) + 1);
+        if ($this->amountHT == null)
+            return null;
+        return (float)number_format($this->amountHT * (($this->taxPercentage / 100) + 1), 2);
     }
 
     /**
@@ -347,7 +350,9 @@ class Facture implements \JsonSerializable
      */
     public function getAmountHT()
     {
-        return $this->amountHT;
+        if($this->amountHT == null)
+            return null;
+        return (float)number_format($this->amountHT, 2);
     }
 
     /**
@@ -363,7 +368,9 @@ class Facture implements \JsonSerializable
      */
     public function getTaxPercentage()
     {
-        return $this->taxPercentage;
+        if ($this->taxPercentage == null)
+            return null;
+        return (float)number_format($this->taxPercentage, 2);
     }
 
     /**

--- a/tests/Treso/FactureIntegrationTest.php
+++ b/tests/Treso/FactureIntegrationTest.php
@@ -178,7 +178,7 @@ class FactureIntegrationTest extends AppTestCase
         $this->assertSame(false, $body->validatedByPerf);
         $this->assertSame(null, $body->validatedByPerfDate);
         $this->assertSame(null, $body->validatedByPerfMember);
-        $this->assertSame(344.45 * ((20.3 / 100) + 1), $body->amountTTC);
+        $this->assertSame((float) number_format(344.45 * ((20.3 / 100) + 1), 2), $body->amountTTC);
         $this->assertSame(false, $body->documents[0]->isUploaded);
         $this->assertSame(false, $body->documents[1]->isUploaded);
         $this->assertSame(false, $body->documents[2]->isUploaded);


### PR DESCRIPTION
Lors de la dernière présentation de Keros, il y avait des problèmes à causes du nombre de virgule sur les valeurs -> 2 décimales après la virgule