### PR TITLE
test delete all facture

### DIFF
--- a/src/Controllers/Treso/FactureController.php
+++ b/src/Controllers/Treso/FactureController.php
@@ -55,6 +55,10 @@ class FactureController
      */
     private $factureDocumentService;
 
+    /**
+     * FactureController constructor.
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->logger = $container->get(Logger::class);
@@ -75,7 +79,7 @@ class FactureController
      */
     public function getFacture(Request $request, Response $response, array $args)
     {
-        $this->logger->debug("Getting facture by ID from " . $request->getServerParams()["REMOTE_ADDR"]);
+        $this->logger->debug("Getting facture " . $args['id']. " from " . $request->getServerParams()["REMOTE_ADDR"]);
 
         $facture = $this->factureService->getOne($args["id"]);
 
@@ -136,6 +140,7 @@ class FactureController
      */
     public function createFacture(Request $request, Response $response, array $args)
     {
+        $this->logger->debug("Creating facture from " . $request->getServerParams()["REMOTE_ADDR"]);
         $body = $request->getParsedBody();
         $body["createdBy"] = $request->getAttribute("userId");
         $this->entityManager->beginTransaction();
@@ -145,9 +150,16 @@ class FactureController
         return $response->withJson($this->addDocumentsToJsonFacture($facture), 201);
     }
 
+    /**
+     * @param Request $request
+     * @param Response $response
+     * @param array $args
+     * @return Response
+     * @throws KerosException
+     */
     public function deleteFacture(Request $request, Response $response, array $args)
     {
-        $this->logger->debug("Deleting facture from " . $request->getServerParams()["REMOTE_ADDR"]);
+        $this->logger->debug("Deleting facture " . $args['id']. " from " . $request->getServerParams()["REMOTE_ADDR"]);
         $this->entityManager->beginTransaction();
         $this->factureService->delete($args['id']);
         $this->entityManager->commit();
@@ -164,7 +176,7 @@ class FactureController
      */
     public function updateFacture(Request $request, Response $response, array $args)
     {
-        $this->logger->debug("Updating facture from " . $request->getServerParams()["REMOTE_ADDR"]);
+        $this->logger->debug("Updating facture " . $args['id']. " from " . $request->getServerParams()["REMOTE_ADDR"]);
         $body = $request->getParsedBody();
 
         $this->entityManager->beginTransaction();
@@ -183,7 +195,7 @@ class FactureController
      */
     public function validateFactureByUa(Request $request, Response $response, array $args)
     {
-        $this->logger->debug("Validating facture by Ua from " . $request->getServerParams()["REMOTE_ADDR"]);
+        $this->logger->debug("Validating facture " . $args['id']. " by Ua " . $request->getAttribute("userId") . " from " . $request->getServerParams()["REMOTE_ADDR"]);
 
         $this->entityManager->beginTransaction();
         $this->factureService->validateByUa($args['id'], $request->getAttribute("userId"));
@@ -201,7 +213,7 @@ class FactureController
      */
     public function validateFactureByPerf(Request $request, Response $response, array $args)
     {
-        $this->logger->debug("Validating facture by Ua from " . $request->getServerParams()["REMOTE_ADDR"]);
+        $this->logger->debug("Validating facture " . $args['id']. " by Perf " . $request->getAttribute("userId") . " from " . $request->getServerParams()["REMOTE_ADDR"]);
 
         $this->entityManager->beginTransaction();
         $this->factureService->validateByPerf($args['id'], $request->getAttribute("userId"));

--- a/src/Entities/Treso/Facture.php
+++ b/src/Entities/Treso/Facture.php
@@ -104,6 +104,12 @@ class Facture implements \JsonSerializable
     protected $validatedByPerfMember;
 
     /**
+     * @var FactureDocument[]
+     * @OneToMany(targetEntity="FactureDocument", mappedBy="facture")
+     */
+    private $relatedDocuments;
+
+    /**
      * Facture constructor.
      * @param $numero
      * @param $fullAddress
@@ -615,5 +621,25 @@ class Facture implements \JsonSerializable
     public function setContactEmail($contactEmail): void
     {
         $this->contactEmail = $contactEmail;
+    }
+
+    /**
+     * @return FactureDocument[]
+     */
+    public function getRelatedDocuments(): array
+    {
+        $relatedDocuments = array();
+        foreach ($this->relatedDocuments as $relatedDocument){
+            $relatedDocuments[] = $relatedDocument;
+        }
+        return $relatedDocuments;
+    }
+
+    /**
+     * @param FactureDocument[] $relatedDocuments
+     */
+    public function setRelatedDocuments(array $relatedDocuments): void
+    {
+        $this->relatedDocuments = $relatedDocuments;
     }
 }

--- a/src/Entities/Treso/FactureDocument.php
+++ b/src/Entities/Treso/FactureDocument.php
@@ -15,6 +15,7 @@ class FactureDocument extends Document implements JsonSerializable
 {
 
     /**
+     * @var Facture|null
      * @ManyToOne(targetEntity="Keros\Entities\Treso\Facture")
      * @JoinColumn(name="factureId", referencedColumnName="id")
      **/
@@ -52,9 +53,9 @@ class FactureDocument extends Document implements JsonSerializable
     }
 
     /**
-     * @return Facture
+     * @return Facture|null
      */
-    public function getFacture() : Facture
+    public function getFacture() : ?Facture
     {
         return $this->facture;
     }

--- a/src/Services/Treso/FactureDocumentService.php
+++ b/src/Services/Treso/FactureDocumentService.php
@@ -162,7 +162,7 @@ class FactureDocumentService
     {
         $factureDocumentTypes = $this->getAll();
         foreach ($factureDocumentTypes as $factureDocumentType) {
-            if ($factureDocumentType->getId() == $documentTypeid && $factureDocumentType->getFacture()->getId() == $factureId)
+            if ($factureDocumentType->getFacture() != null && $factureDocumentType->getId() == $documentTypeid && $factureDocumentType->getFacture()->getId() == $factureId)
                 return true;
         }
         return false;

--- a/src/Services/Treso/FactureService.php
+++ b/src/Services/Treso/FactureService.php
@@ -98,17 +98,21 @@ class FactureService
         return $facture;
     }
 
+    /**
+     * @param int $id
+     * @throws KerosException
+     */
     public function delete(int $id): void
     {
         $id = Validator::requiredId($id);
         $facture = $this->getOne($id);
+        $facture->setRelatedDocuments(array());
         $this->factureDataService->delete($facture);
     }
 
     public function getOne(int $id): Facture
     {
         $id = Validator::requiredId($id);
-
         $facture = $this->factureDataService->getOne($id);
         if (!$facture) {
             throw new KerosException("The facture could not be found", 404);

--- a/src/Tools/Database/keros.sql
+++ b/src/Tools/Database/keros.sql
@@ -390,11 +390,11 @@ CREATE TABLE treso_facture_document_type (
 DROP TABLE IF EXISTS treso_facture_document;
 CREATE TABLE treso_facture_document (
   id int(11) AUTO_INCREMENT,
-  factureId int(11) NOT NULL,
+  factureId int(11),
   factureDocumentTypeId int(11) NOT NULL,
   PRIMARY KEY (id),
   CONSTRAINT fk_treso_document_core_document FOREIGN KEY (id) REFERENCES core_document(id),
-  CONSTRAINT `fk_treso_facture_document_treso_facture` FOREIGN KEY (factureId) REFERENCES treso_facture(`id`),
+  CONSTRAINT `fk_treso_facture_document_treso_facture` FOREIGN KEY (factureId) REFERENCES treso_facture(`id`) ON DELETE SET NULL,
   CONSTRAINT fk_treso_document_treso_document_type FOREIGN KEY (factureDocumentTypeId) REFERENCES treso_facture_document_type(id)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 

--- a/src/Tools/Database/kerosData.sql
+++ b/src/Tools/Database/kerosData.sql
@@ -231,6 +231,7 @@ INSERT INTO `ua_study_document`(id, studyId, studyDocumentTypeId) VALUES
   (1, 1, 2),
   (2, 1, 3);
 
+#Penser à mettre à jour le nombre de facture dans FactureIntegrationTest::testDeleteAllExistingFacturesShouldReturn204
 TRUNCATE TABLE treso_facture;
 INSERT INTO treso_facture (id, numero, addressId, clientName , contactName, contactEmail, studyId, typeId, amountDescription,
                             subject, agreementSignDate, amountHT, taxPercentage, dueDate , additionalInformation, createdDate, createdById,

--- a/tests/Treso/FactureIntegrationTest.php
+++ b/tests/Treso/FactureIntegrationTest.php
@@ -8,7 +8,6 @@ use Slim\Http\Request;
 
 class FactureIntegrationTest extends AppTestCase
 {
-
     public function testValidateByUaShouldReturn200()
     {
         $env = Environment::mock([
@@ -289,5 +288,19 @@ class FactureIntegrationTest extends AppTestCase
         $response = $this->app->run(false);
 
         $this->assertSame(400, $response->getStatusCode());
+    }
+
+    public function testDeleteAllExistingFacturesShouldReturn204()
+    {
+        for($id = 1;  $id <= 4; $id++) {
+            $env = Environment::mock([
+                'REQUEST_METHOD' => 'DELETE',
+                'REQUEST_URI' => "/api/v1/treso/facture/$id",
+            ]);
+            $req = Request::createFromEnvironment($env);
+            $this->app->getContainer()['request'] = $req;
+            $response = $this->app->run(false);
+            $this->assertSame(204, $response->getStatusCode());
+        }
     }
 }


### PR DESCRIPTION
bon, c'est pas parfait mais au moins ça fonctionne.

En voulant faire comme #118 j'ai une erreur 😞 
```
File : C:\Users\Paul\Documents\Keros-Back\src\DataServices\Treso\FactureDataService.php. Line : 57. Message : Failed to delete facture : A new entity was found through the relationship 'Keros\Entities\Treso\FactureDocument#facture' that was not configured to cascade persist operations for entity: Keros\Entities\Treso\Facture@0000000038404324000000005f65be72. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'Keros\Entities\Treso\Facture#__toString()' to get a clue..
	at C:\Users\Paul\Documents\Keros-Back\src\Services\Treso\FactureService.php delete:110
	at C:\Users\Paul\Documents\Keros-Back\src\Controllers\Treso\FactureController.php delete:164
	at  deleteFacture:
	at C:\Users\Paul\Documents\Keros-Back\vendor\slim\slim\Slim\Handlers\Strategies\RequestResponse.php call_user_func:41
	at C:\Users\Paul\Documents\Keros-Back\vendor\slim\slim\Slim\Route.php __invoke:356 [] []
```
Pas trouvé de solution, mais ça devrait faire l'affaire