### PR TITLE
Set hasPaid to false on inscription

### DIFF
--- a/src/Services/Sg/MemberInscriptionService.php
+++ b/src/Services/Sg/MemberInscriptionService.php
@@ -81,7 +81,7 @@ class   MemberInscriptionService
         $genderId = Validator::requiredId($fields['genderId']);
         $gender = $this->genderService->getOne($genderId);
         $birthday = Validator::requiredDate($fields['birthday']);
-        $hasPaid = Validator::optionalBool(isset($fields['hasPaid']) ? $fields['hasPaid'] : false);
+        $hasPaid = false;
         $droitImage = Validator::requiredBool($fields['droitImage']);
         $createdDate = new \DateTime();
 
@@ -181,7 +181,6 @@ class   MemberInscriptionService
         $genderId = Validator::requiredId($fields['genderId']);
         $gender = $this->genderService->getOne($genderId);
         $birthday = Validator::requiredDate($fields['birthday']);
-        $hasPaid = Validator::optionalBool(isset($fields['hasPaid']) ? $fields['hasPaid'] : false);
         $droitImage = Validator::requiredBool($fields['droitImage']);
 
         $memberInscription->setFirstName($firstName);
@@ -194,7 +193,6 @@ class   MemberInscriptionService
         $memberInscription->setWantedPole($wantedPole);
         $memberInscription->setGender($gender);
         $memberInscription->setBirthday($birthday);
-        $memberInscription->setHasPaid($hasPaid);
         $memberInscription->setDroitImage($droitImage);
         $this->addressService->update($memberInscription->getAddress()->getId(), $fields["address"]);
 

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -106,7 +106,6 @@ class MemberInscriptionIntegrationTest extends AppTestCase
                 'postalCode' => 66666,
                 'countryId' => 133,
             ),
-            'hasPaid' => true,
             'droitImage' => true,
         );
 
@@ -136,7 +135,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame(5, $body->wantedPole->id);
         $this->assertSame('je sais pas quoi mettre', $body->address->line1);
         $this->assertSame('Lorem ipsum', $body->address->city);
-        $this->assertSame(true, $body->hasPaid);
+        $this->assertSame(false, $body->hasPaid);
         $this->assertSame(true, $body->droitImage);
         $this->assertSame(intval($dateDiff),0);
         $this->assertIsArray($body->documents);
@@ -169,7 +168,6 @@ class MemberInscriptionIntegrationTest extends AppTestCase
                 'postalCode' => 66666,
                 'countryId' => 133,
             ),
-            'hasPaid' => true,
             'droitImage' => true,
         );
 
@@ -199,7 +197,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame(5, $body->wantedPole->id);
         $this->assertSame('je sais pas quoi mettre', $body->address->line1);
         $this->assertSame('Lorem ipsum', $body->address->city);
-        $this->assertSame(true, $body->hasPaid);
+        $this->assertSame(false, $body->hasPaid);
         $this->assertSame(true, $body->droitImage);
         $this->assertSame(intval($dateDiff),0);
         $this->assertIsArray($body->documents);
@@ -423,7 +421,6 @@ class MemberInscriptionIntegrationTest extends AppTestCase
                 'postalCode' => 66666,
                 'countryId' => 133,
             ),
-            'hasPaid' => true,
             'droitImage' => true,
         );
 
@@ -450,7 +447,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame(5, $body->wantedPole->id);
         $this->assertSame('je sais pas quoi mettre', $body->address->line1);
         $this->assertSame('Lorem ipsum', $body->address->city);
-        $this->assertSame(true, $body->hasPaid);
+        $this->assertSame(false, $body->hasPaid);
         $this->assertSame(true, $body->droitImage);
     }
 
@@ -479,7 +476,6 @@ class MemberInscriptionIntegrationTest extends AppTestCase
                 'postalCode' => 66666,
                 'countryId' => 133,
             ),
-            'hasPaid' => true,
             'droitImage' => true,
         );
 


### PR DESCRIPTION
This is to set the `hasPaid` attribute to `false` upon creation (POST and PUT) of `memberInscription`.
`hasPaid` should only be changed to true by calling `confirmPaymentMemberInscription`.