### PR TITLE
Fix/is upload member inscription

### DIFF
--- a/src/Services/Sg/MemberInscriptionDocumentService.php
+++ b/src/Services/Sg/MemberInscriptionDocumentService.php
@@ -125,11 +125,32 @@ class MemberInscriptionDocumentService
      * @param int $id
      * @throws KerosException
      */
-    public function delete(int $id){
+    public function delete(int $id)
+    {
         $id = Validator::requiredId($id);
         $memberInscriptionDocument = $this->memberInscriptionDocumentDataService->getOne($id);
         unlink($this->directoryManager->normalizePath($this->kerosConfig["MEMBER_INSCRIPTION_DOCUMENT_DIRECTORY"] . $memberInscriptionDocument->getLocation()));
         $this->memberInscriptionDocumentDataService->delete($memberInscriptionDocument);
+    }
+
+    /**
+     * @param int $documentTypeId
+     * @param int $memberId
+     * @return bool
+     * @throws KerosException
+     */
+    public function documentTypeIsUploadedForMemberInscription(int $documentTypeId, int $memberId): bool
+    {
+        $memberInscriptionDocuments = $this->getAll();
+        foreach ($memberInscriptionDocuments as $memberInscriptionDocument) {
+            //if the MemberInscription related to this document is null, it means that the document is now related to is accepted Member
+            if (!is_null($memberInscriptionDocument->getMemberInscription())) {
+                if ($memberInscriptionDocument->getMemberInscriptionDocumentType()->getId() == $documentTypeId && $memberInscriptionDocument->getMemberInscription()->getId() == $memberId) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -139,21 +160,5 @@ class MemberInscriptionDocumentService
     public function getAll(): array
     {
         return $this->memberInscriptionDocumentDataService->getAll();
-    }
-
-    /**
-     * @param int $documentTypeid
-     * @param int $memberId
-     * @return bool
-     * @throws KerosException
-     */
-    public function documentTypeIsUploadedForMemberInscription(int $documentTypeid, int $memberId): bool
-    {
-        $memberInscriptionDocumentTypes = $this->getAll();
-        foreach ($memberInscriptionDocumentTypes as $memberInscriptionDocumentType) {
-            if ($memberInscriptionDocumentType->getId() == $documentTypeid && $memberInscriptionDocumentType->getMemberInscription()->getId() == $memberId)
-                return true;
-        }
-        return false;
     }
 }

--- a/src/Services/Sg/MemberInscriptionDocumentTypeService.php
+++ b/src/Services/Sg/MemberInscriptionDocumentTypeService.php
@@ -58,6 +58,7 @@ class MemberInscriptionDocumentTypeService
 
     /**
      * @return MemberInscriptionDocumentType[]
+     * @throws KerosException
      */
     public function getAll(): array
     {

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -52,7 +52,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame(1, $body->content[0]->documents[0]->id);
         $this->assertSame("Fiche inscription membre", $body->content[0]->documents[0]->name);
         $this->assertSame(true, $body->content[0]->documents[0]->isTemplatable);
-        $this->assertSame(false, $body->content[0]->documents[0]->isUploaded);
+        $this->assertSame(true, $body->content[0]->documents[0]->isUploaded);
         $this->assertSame(0, $body->meta->page);
         $this->assertSame(2, $body->meta->totalPages);
         $this->assertSame(30, $body->meta->totalItems);
@@ -263,7 +263,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame(1, $body->documents[0]->id);
         $this->assertSame("Fiche inscription membre", $body->documents[0]->name);
         $this->assertSame(true, $body->documents[0]->isTemplatable);
-        $this->assertSame(false, $body->documents[0]->isUploaded);
+        $this->assertSame(true, $body->documents[0]->isUploaded);
     }
 
     /**


### PR DESCRIPTION
fix a bug :

> Yo une erreur à signaler au back :
> `https://pre-keros-api.etic-insa.com/api/v1/sg/membre-inscription/5/document/1 POST `
> L'attribut isUploaded ne passe pas à true une fois que j'ai upload un fichier (j'ai upload par Postman avec la route au-dessus puis j'ai GET et j'ai bien récupérer le doc, cependant quand je vérifie ici
> `https://pre-keros-api.etic-insa.com/api/v1/sg/membre-inscription/5 GET`
> L'attribut isUploaded du document 1 reste à false

from Keros Front