### PR TITLE
Fix missing parameters on consultant and member inscriptions.

### DIFF
--- a/src/Controllers/Sg/ConsultantInscriptionController.php
+++ b/src/Controllers/Sg/ConsultantInscriptionController.php
@@ -88,7 +88,7 @@ class ConsultantInscriptionController
     {
         $this->logger->debug("Get page consultantInscriptions from " . $request->getServerParams()["REMOTE_ADDR"]);
         $queryParams = $request->getQueryParams();
-        $params = new RequestParameters($queryParams, ConsultantInscription::getSearchFields());
+        $params = new RequestParameters($queryParams, ConsultantInscription::getSearchFields(), ConsultantInscription::getFilterFields());
 
         $consultantInscriptions = $this->consultantInscriptionService->getPage($params);
         $count = $this->consultantInscriptionService->getCount($params);

--- a/src/Entities/Sg/ConsultantInscription.php
+++ b/src/Entities/Sg/ConsultantInscription.php
@@ -2,13 +2,6 @@
 
 namespace Keros\Entities\Sg;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
-use Doctrine\ORM\Mapping\Table;
 use JsonSerializable;
 use Keros\Entities\Core\Address;
 use Keros\Entities\Core\Country;

--- a/src/Entities/Sg/ConsultantInscription.php
+++ b/src/Entities/Sg/ConsultantInscription.php
@@ -2,6 +2,13 @@
 
 namespace Keros\Entities\Sg;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Table;
 use JsonSerializable;
 use Keros\Entities\Core\Address;
 use Keros\Entities\Core\Country;
@@ -220,6 +227,11 @@ class ConsultantInscription implements JsonSerializable
     }
 
     public static function getSearchFields(): array
+    {
+        return ['firstName', 'lastName', 'email', 'phoneNumber'];
+    }
+
+    public static function getFilterFields(): array
     {
         return ['firstName', 'lastName', 'email', 'phoneNumber', 'outYear'];
     }

--- a/src/Entities/Sg/MemberInscription.php
+++ b/src/Entities/Sg/MemberInscription.php
@@ -2,14 +2,6 @@
 
 namespace Keros\Entities\Sg;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\ManyToOne;
-use Doctrine\ORM\Mapping\OneToMany;
-use Doctrine\ORM\Mapping\Table;
 use JsonSerializable;
 use Keros\Entities\Core\Address;
 use Keros\Entities\Core\Country;

--- a/src/Entities/Sg/MemberInscription.php
+++ b/src/Entities/Sg/MemberInscription.php
@@ -2,6 +2,14 @@
 
 namespace Keros\Entities\Sg;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Table;
 use JsonSerializable;
 use Keros\Entities\Core\Address;
 use Keros\Entities\Core\Country;
@@ -183,12 +191,12 @@ class MemberInscription implements JsonSerializable
 
     public static function getSearchFields(): array
     {
-        return ['firstName', 'lastName', 'email', 'phoneNumber', 'outYear'];
+        return ['firstName', 'lastName', 'email', 'phoneNumber'];
     }
 
     public static function getFilterFields(): array
     {
-        return ['hasPaid'];
+        return ['hasPaid', 'firstName', 'lastName', 'email', 'phoneNumber', 'outYear'];
     }
 
     /**

--- a/tests/Sg/ConsultantInscriptionIntegrationTest.php
+++ b/tests/Sg/ConsultantInscriptionIntegrationTest.php
@@ -785,7 +785,7 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
-    public function testGetPage1MemberInscriptionShouldReturn200()
+    public function testGetPage1ConsultantInscriptionShouldReturn200()
     {
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
@@ -798,5 +798,114 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(1, count($body->content));
+    }
+
+
+    public function testGetConsultantInscriptionFilterFirstNameShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?firstName=Clark',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertContains('Clark', $consultantInscription->firstName);
+        }
+    }
+
+    public function testGetConsultantInscriptionFilterLastNameShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?lastName=Wayne',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertContains('Wayne', $consultantInscription->lastName);
+        }
+    }
+
+    public function testGetConsultantInscriptionFilterEmailShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?email=bruce.wayne@batman.com',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertContains('bruce.wayne@batman.com', $consultantInscription->email);
+        }
+    }
+
+    public function testGetConsultantInscriptionFilterPhoneNumberShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?phoneNumber=0033123456789',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertContains('0033123456789', $consultantInscription->phoneNumber);
+        }
+    }
+
+    public function testGetConsultantInscriptionFilterOutYearShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?outYear=2022',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertEquals(2022, $consultantInscription->outYear);
+        }
+    }
+
+    public function testGetConsultantInscriptionSearchShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/consultant-inscription?search=Cla',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $consultantInscription){
+            $this->assertContains('Clark', array($consultantInscription->firstName, $consultantInscription->lastName, $consultantInscription->phoneNumber, $consultantInscription->email));
+        }
     }
 }

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -661,4 +661,112 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertEquals(12, count($body->content));
         $this->assertSame(false, $body->content[0]->hasPaid);
     }
+
+    public function testGetMemberInscriptionFilterFirstNameShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?firstName=Clark',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertContains('Clark', $memberInscription->firstName);
+        }
+    }
+
+    public function testGetMemberInscriptionFilterLastNameShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?lastName=Wayne',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertContains('Wayne', $memberInscription->lastName);
+        }
+    }
+
+    public function testGetMemberInscriptionFilterEmailShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?email=bruce.wayne@batman.com',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertContains('bruce.wayne@batman.com', $memberInscription->email);
+        }
+    }
+
+    public function testGetMemberInscriptionFilterPhoneNumberShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?phoneNumber=0033123456789',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertContains('0033123456789', $memberInscription->phoneNumber);
+        }
+    }
+
+    public function testGetMemberInscriptionFilterOutYearShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?outYear=2022',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertEquals(2022, $memberInscription->outYear);
+        }
+    }
+
+    public function testGetMemberInscriptionSearchShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription?search=Cla',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+
+        foreach ($body->content as $memberInscription){
+            $this->assertContains('Clark', array($memberInscription->firstName, $memberInscription->lastName, $memberInscription->phoneNumber, $memberInscription->email));
+        }
+    }
 }


### PR DESCRIPTION
 Using RequestParamerters Keros Class improvement done by Sad :smile:.

Fix utilisation des query parameters `firstName`, `lastName`, `phoneNumber `et `outYear`.

ex : `/api/v1/sg/consultant-inscription?email=bruce.wayne@batman.com`.

`outYear` à été enlever des search parameters car ça ne fonctionnait pas (parce que on ne peux pas faire un contains avec des entier, je pense).

Doc mise à jour