### PR TITLE
Feature/company filter change

### DIFF
--- a/src/DataServices/Core/MemberDataService.php
+++ b/src/DataServices/Core/MemberDataService.php
@@ -134,10 +134,7 @@ class MemberDataService
                         } elseif ($key == 'year') {
                             $whereStatement .= 'mp.year = :year';
                             $whereParameters[':' . $key] = $value;
-                        } elseif ($key == 'company') {
-                            $whereStatement .= 'm.' . $key . ' LIKE :' . $key;
-                            $whereParameters[':' . $key] = '%' . $value . '%';
-                        } elseif ($key == 'firstName' || $key == 'lastName') {
+                        } elseif ($key == 'firstName' || $key == 'lastName' || $key == 'company') {
                             // where with the form: 'm.key = :key'
                             $whereStatement .= 'm.' . $key . ' LIKE :' . $key;
                             $whereParameters[':' . $key] = '%' . $value . '%';

--- a/src/DataServices/Core/MemberDataService.php
+++ b/src/DataServices/Core/MemberDataService.php
@@ -135,8 +135,8 @@ class MemberDataService
                             $whereStatement .= 'mp.year = :year';
                             $whereParameters[':' . $key] = $value;
                         } elseif ($key == 'company') {
-                            $whereStatement .= 'm.' . $key . ' = :' . $key;
-                            $whereParameters[':' . $key] = $value;
+                            $whereStatement .= 'm.' . $key . ' LIKE :' . $key;
+                            $whereParameters[':' . $key] = '%' . $value . '%';
                         } elseif ($key == 'firstName' || $key == 'lastName') {
                             // where with the form: 'm.key = :key'
                             $whereStatement .= 'm.' . $key . ' LIKE :' . $key;

--- a/src/Tools/Database/kerosData.sql
+++ b/src/Tools/Database/kerosData.sql
@@ -187,7 +187,7 @@ INSERT INTO core_ticket (id, userId, title, message, type, status) VALUES
 #si vous ajouter des core_member, pensez à mettre à jour MemberIntegrationTest.testDeleteAllExistingMemberShouldReturn204
 TRUNCATE TABLE core_member;
 INSERT INTO core_member (id, genderId, firstName, lastName, birthday, telephone, email, addressId, schoolYear, departmentId, company, profilePicture, droitImage, createdDate, isAlumni) VALUES
-  (1, 1, 'Conor', 'Breeze', STR_TO_DATE('1975-12-25', '%Y-%m-%d'), '+332541254', 'fake.mail@fake.com', 2, 3, 1, 'Google', '1c518c591e1be2f2703dd8c9bb77dbb5.jpg', true, STR_TO_DATE('2019/9/1', '%Y/%m/%d'), false),
+  (1, 1, 'Conor', 'Breeze', STR_TO_DATE('1975-12-25', '%Y-%m-%d'), '+332541254', 'fake.mail@fake.com', 2, 3, 1, 'Danone Group', '1c518c591e1be2f2703dd8c9bb77dbb5.jpg', true, STR_TO_DATE('2019/9/1', '%Y/%m/%d'), false),
   (3, 1, 'Laurence', 'Tainturière', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.mail3@fake.com', 3, 5, 2, NULL, NULL, true, STR_TO_DATE('2019/9/1', '%Y/%m/%d'), false),
   (4, 3, 'Stéphane4', 'McMahon', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'fake.maly4@fake.com', 6, 3, 4, NULL, NULL, false, STR_TO_DATE('2019/9/1', '%Y/%m/%d'), false),
   (6, 3, 'SuperPrenom', 'SuperNom', STR_TO_DATE('1987-12-2', '%Y-%m-%d'), '+337425254', 'super@vraimentsuper.com', 9, 3, 4, NULL, NULL, true, STR_TO_DATE('2019/9/1', '%Y/%m/%d'), false),

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -86,7 +86,7 @@ class MemberIntegrationTest extends AppTestCase
         $body = json_decode($response->getBody());
         $this->assertNotNull($body->content);
         $this->assertSame(1, sizeof($body->content));
-        $this->assertSame(1 $body->content[0]->id);
+        $this->assertSame(1, $body->content[0]->id);
         $this->assertSame("Danone Group", $body->content[0]->company);
     }
 

--- a/tests/Core/MemberIntegrationTest.php
+++ b/tests/Core/MemberIntegrationTest.php
@@ -70,6 +70,26 @@ class MemberIntegrationTest extends AppTestCase
         $this->assertSame(3, $body->content[0]->positions[2]->id);
     }
 
+    public function testLikeSearchMemberCompanyShouldReturn200()
+    {
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/api/v1/core/member?company=danone',
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody());
+        $this->assertNotNull($body->content);
+        $this->assertSame(1, sizeof($body->content));
+        $this->assertSame(1 $body->content[0]->id);
+        $this->assertSame("Danone Group", $body->content[0]->company);
+    }
+
     public function testSearchMemberShouldReturn200()
     {
         $env = Environment::mock([


### PR DESCRIPTION
Request from an alumni.
Company names can be long and confusing : e.g. "Setec ALS Lyon" or "Amadeus SAS". Hence it's better to implement the same kind of filtering as for `firstName` and `lastName`, i.e. use the `LIKE` operator for filtering instead of the `=` operator.
Now a filtering with `company=setec` will fetch the same results as `company=setec als lyon`.