### PR TITLE
Bug fix/consultant file upload

### DIFF
--- a/src/Tools/Helpers/ConsultantFileHelper.php
+++ b/src/Tools/Helpers/ConsultantFileHelper.php
@@ -33,7 +33,7 @@ class ConsultantFileHelper
         ),
         'documentScolaryCertificate' => array(
             'name' => 'documentScolaryCertificate',
-            'set' => 'createDocumentScolaryCertificate',
+            'set' => 'setDocumentScolaryCertificate',
             'get' => 'getDocumentScolaryCertificate',
             'directory_key' => 'CONSULTANT_SCOLARY_CERTIFICATE_DIRECTORY',
             'isRequired' => false,
@@ -42,7 +42,7 @@ class ConsultantFileHelper
         ),
         'documentRIB' => array(
             'name' => 'documentRIB',
-            'set' => 'createDocumentRIB',
+            'set' => 'setDocumentRIB',
             'get' => 'getDocumentRIB',
             'directory_key' => 'CONSULTANT_RIB_DIRECTORY',
             'isRequired' => false,
@@ -51,7 +51,7 @@ class ConsultantFileHelper
         ),
         'documentVitaleCard' => array(
             'name' => 'documentVitaleCard',
-            'set' => 'createDocumentVitaleCard',
+            'set' => 'setDocumentVitaleCard',
             'get' => 'getDocumentVitaleCard',
             'directory_key' => 'CONSULTANT_VITALE_CARD_DIRECTORY',
             'isRequired' => false,
@@ -60,7 +60,7 @@ class ConsultantFileHelper
         ),
         'documentResidencePermit' => array(
             'name' => 'documentResidencePermit',
-            'set' => 'createDocumentResidencePermit',
+            'set' => 'setDocumentResidencePermit',
             'get' => 'getDocumentResidencePermit',
             'directory_key' => 'CONSULTANT_RESIDENCE_PERMIT_DIRECTORY',
             'isRequired' => false,
@@ -69,7 +69,7 @@ class ConsultantFileHelper
         ),
         'documentCVEC' => array(
             'name' => 'documentCVEC',
-            'set' => 'createDocumentCVEC',
+            'set' => 'setDocumentCVEC',
             'get' => 'getDocumentCVEC',
             'directory_key' => 'CONSULTANT_CVEC_DIRECTORY',
             'isRequired' => false,

--- a/src/Tools/Helpers/ConsultantInscriptionFileHelper.php
+++ b/src/Tools/Helpers/ConsultantInscriptionFileHelper.php
@@ -33,7 +33,7 @@ class ConsultantInscriptionFileHelper
         ),
         'documentScolaryCertificate' => array(
             'name' => 'documentScolaryCertificate',
-            'set' => 'createDocumentScolaryCertificate',
+            'set' => 'setDocumentScolaryCertificate',
             'get' => 'getDocumentScolaryCertificate',
             'directory_key' => 'INSCRIPTION_SCOLARY_CERTIFICATE_DIRECTORY',
             'isRequired' => true,
@@ -42,7 +42,7 @@ class ConsultantInscriptionFileHelper
         ),
         'documentRIB' => array(
             'name' => 'documentRIB',
-            'set' => 'createDocumentRIB',
+            'set' => 'setDocumentRIB',
             'get' => 'getDocumentRIB',
             'directory_key' => 'INSCRIPTION_RIB_DIRECTORY',
             'isRequired' => true,
@@ -51,7 +51,7 @@ class ConsultantInscriptionFileHelper
         ),
         'documentVitaleCard' => array(
             'name' => 'documentVitaleCard',
-            'set' => 'createDocumentVitaleCard',
+            'set' => 'setDocumentVitaleCard',
             'get' => 'getDocumentVitaleCard',
             'directory_key' => 'INSCRIPTION_VITALE_CARD_DIRECTORY',
             'isRequired' => true,
@@ -60,7 +60,7 @@ class ConsultantInscriptionFileHelper
         ),
         'documentResidencePermit' => array(
             'name' => 'documentResidencePermit',
-            'set' => 'createDocumentResidencePermit',
+            'set' => 'setDocumentResidencePermit',
             'get' => 'getDocumentResidencePermit',
             'directory_key' => 'INSCRIPTION_RESIDENCE_PERMIT_DIRECTORY',
             'isRequired' => false,
@@ -69,7 +69,7 @@ class ConsultantInscriptionFileHelper
         ),
         'documentCVEC' => array(
             'name' => 'documentCVEC',
-            'set' => 'createDocumentCVEC',
+            'set' => 'setDocumentCVEC',
             'get' => 'getDocumentCVEC',
             'directory_key' => 'INSCRIPTION_CVEC_DIRECTORY',
             'isRequired' => true,

--- a/tests/Core/ConsultantIntegrationTest.php
+++ b/tests/Core/ConsultantIntegrationTest.php
@@ -477,10 +477,170 @@ class ConsultantIntegrationTest extends AppTestCase
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
-    public function testPostConsultantDocumentShouldReturn201()
+    public function testPostConsultantDocumentIdentityShouldReturn201()
     {
 
         $filename = 'documentIdentity';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/core/consultant/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantDocumentScolaryCertificateShouldReturn201()
+    {
+
+        $filename = 'documentScolaryCertificate';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/core/consultant/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantDocumentRIBShouldReturn201()
+    {
+
+        $filename = 'documentRIB';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/core/consultant/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantDocumentVitaleCardShouldReturn201()
+    {
+
+        $filename = 'documentVitaleCard';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/core/consultant/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantDocumentResidencePermitShouldReturn201()
+    {
+
+        $filename = 'documentResidencePermit';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/core/consultant/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantDocumentCVECShouldReturn201()
+    {
+
+        $filename = 'documentCVEC';
         $uploaded_files = array();
 
         $filename_ext = $filename . '.pdf';

--- a/tests/Sg/ConsultantInscriptionIntegrationTest.php
+++ b/tests/Sg/ConsultantInscriptionIntegrationTest.php
@@ -503,7 +503,7 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
-    public function testPostConsultantInscriptionDocumentShouldReturn201()
+    public function testPostConsultantInscriptionDocumentIdentityShouldReturn201()
     {
 
         $filename = 'documentIdentity';
@@ -535,35 +535,160 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
-    public function testPostConsultantInscriptionAllDocumentsShouldReturn201()
+    public function testPostConsultantInscriptionDocumentScolaryCertificateShouldReturn201()
     {
-        $filenames = array('documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC');
 
-        foreach ($filenames as $filename) {
-            $uploaded_files = array();
+        $filename = 'documentScolaryCertificate';
+        $uploaded_files = array();
 
-            $filename_ext = $filename . '.pdf';
-            $temp_file = FileHelper::makeNewFile($filename_ext);
-            $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
 
 
-            $env = Environment::mock([
-                'REQUEST_METHOD' => 'POST',
-                'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
-            ]);
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+        ]);
 
-            $req = Request::createFromEnvironment($env);
-            $req = $req->withUploadedFiles($uploaded_files);
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
 
-            $this->app->getContainer()['request'] = $req;
-            $response = $this->app->run(false);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
 
-            FileHelper::closeFile($temp_file);
-            FileHelper::deleteFile($filename_ext);
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
 
-            $this->assertSame(201, $response->getStatusCode());
-        }
-        
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantInscriptionDocumentRIBShouldReturn201()
+    {
+
+        $filename = 'documentRIB';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantInscriptionDocumentVitaleCardShouldReturn201()
+    {
+
+        $filename = 'documentVitaleCard';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantInscriptionDocumentResidencePermitShouldReturn201()
+    {
+
+        $filename = 'documentResidencePermit';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function testPostConsultantInscriptionDocumentCVECShouldReturn201()
+    {
+
+        $filename = 'documentCVEC';
+        $uploaded_files = array();
+
+        $filename_ext = $filename . '.pdf';
+        $temp_file = FileHelper::makeNewFile($filename_ext);
+        $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withUploadedFiles($uploaded_files);
+
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+
+        FileHelper::closeFile($temp_file);
+        FileHelper::deleteFile($filename_ext);
+
+        $this->assertSame(201, $response->getStatusCode());
     }
 
     /**

--- a/tests/Sg/ConsultantInscriptionIntegrationTest.php
+++ b/tests/Sg/ConsultantInscriptionIntegrationTest.php
@@ -537,7 +537,7 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      */
     public function testPostConsultantInscriptionAllDocumentsShouldReturn201()
     {
-        $filenames = ['documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC'];
+        $filenames = array('documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC');
 
         foreach ($filenames as $filename) {
             $uploaded_files = array();

--- a/tests/Sg/ConsultantInscriptionIntegrationTest.php
+++ b/tests/Sg/ConsultantInscriptionIntegrationTest.php
@@ -537,7 +537,7 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      */
     public function testPostConsultantInscriptionAllDocumentsShouldReturn201()
     {
-        $filenames = ['documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC']
+        $filenames = ['documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC'];
 
         foreach ($filenames as $filename) {
             $uploaded_files = array();

--- a/tests/Sg/ConsultantInscriptionIntegrationTest.php
+++ b/tests/Sg/ConsultantInscriptionIntegrationTest.php
@@ -535,6 +535,41 @@ class ConsultantInscriptionIntegrationTest extends AppTestCase
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
+    public function testPostConsultantInscriptionAllDocumentsShouldReturn201()
+    {
+        $filenames = ['documentIdentity', 'documentScolaryCertificate', 'documentRIB', 'documentVitaleCard', 'documentResidencePermit', 'documentCVEC']
+
+        foreach ($filenames as $filename) {
+            $uploaded_files = array();
+
+            $filename_ext = $filename . '.pdf';
+            $temp_file = FileHelper::makeNewFile($filename_ext);
+            $uploaded_files[$filename] = FileHelper::getUploadedFile($filename_ext);
+
+
+            $env = Environment::mock([
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => "/api/v1/sg/consultant-inscription/2/document/$filename",
+            ]);
+
+            $req = Request::createFromEnvironment($env);
+            $req = $req->withUploadedFiles($uploaded_files);
+
+            $this->app->getContainer()['request'] = $req;
+            $response = $this->app->run(false);
+
+            FileHelper::closeFile($temp_file);
+            FileHelper::deleteFile($filename_ext);
+
+            $this->assertSame(201, $response->getStatusCode());
+        }
+        
+    }
+
+    /**
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
     public function testPostConsultantInscriptionDocumentUnacceptedFormatShouldReturn400()
     {
 


### PR DESCRIPTION
The bug was probably triggered by an incomplete refactoring of the consultant and consultantInscription classes. The `create` keywords were replaced by `set` but in the `ConsultantFileHelper` and `ConsultantInscriptionFileHelper` the keywords were updated only for `documentIdentity`.
Both issues were corrected and additional tests were added to prevent a similar bug.

(However the root cause of the problem was me trying to be a smartass and using 'user functions' whose syntax errors cannot be detected by the parser until that specific function is called 🙁 )