### PR TITLE
PhoneNumber required in member inscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor
 .idea
 *.iml
 
+
 # Ignore logs but keep directory
 logs
 

--- a/src/Services/Core/AddressService.php
+++ b/src/Services/Core/AddressService.php
@@ -26,6 +26,10 @@ class AddressService
      */
     private $logger;
 
+    /**
+     * AddressService constructor.
+     * @param ContainerInterface $container
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->addressDataService = $container->get(AddressDataService::class);

--- a/src/Services/Sg/MemberInscriptionService.php
+++ b/src/Services/Sg/MemberInscriptionService.php
@@ -77,7 +77,7 @@ class   MemberInscriptionService
         $departmentId = Validator::requiredId($fields["departmentId"]);
         $department = $this->departmentService->getOne($departmentId);
         $email = Validator::requiredEmail($fields["email"]);
-        $phoneNumber = Validator::optionalPhone(isset($fields["phoneNumber"]) ? $fields["phoneNumber"] : null);
+        $phoneNumber = Validator::requiredPhone($fields["phoneNumber"]);
         $outYear = Validator::requiredInt($fields["outYear"]);
         $nationalityId = Validator::requiredId($fields["nationalityId"]);
         $nationality = $this->countryService->getOne($nationalityId);
@@ -180,7 +180,7 @@ class   MemberInscriptionService
         $departmentId = Validator::requiredId($fields["departmentId"]);
         $department = $this->departmentService->getOne($departmentId);
         $email = Validator::requiredEmail($fields["email"]);
-        $phoneNumber = Validator::optionalPhone(isset($fields["phoneNumber"]) ? $fields["phoneNumber"] : $memberInscription->getPhoneNumber());
+        $phoneNumber = Validator::requiredPhone($fields["phoneNumber"]);
         $outYear = Validator::optionalInt(isset($fields["outYear"]) ? $fields["outYear"] : $memberInscription->getOutYear());
         $nationalityId = Validator::requiredId($fields["nationalityId"]);
         $nationality = $this->countryService->getOne($nationalityId);

--- a/src/Tools/Database/keros.sql
+++ b/src/Tools/Database/keros.sql
@@ -424,7 +424,7 @@ CREATE TABLE sg_member_inscription (
   genderId int(11) NOT NULL,
   departmentId int(11) NOT NULL,
   email varchar(255) NOT NULL,
-  phoneNumber varchar(255),
+  phoneNumber varchar(255) NOT NULL,
   outYear int NOT NULL,
   nationalityId int(11) NOT NULL,
   wantedPoleId int(11) NOT NULL,

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -771,7 +771,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         }
     }
 
-    public function testPostMemberWithoutPhoneNumberInscriptionShouldReturn400()
+    public function testPostMemberWithoutPhoneNumberInscriptionShouldReturn500()
     {
         $post_body = array(
             'firstName' => 'Thanos',
@@ -801,6 +801,6 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $req = $req->withParsedBody($post_body);
         $this->app->getContainer()['request'] = $req;
         $response = $this->app->run(false);
-        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(500, $response->getStatusCode());
     }
 }

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -178,6 +178,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
             'birthday' => '1000-01-01',
             'departmentId' => 4,
             'email' => 'thanos@claquementdedoigts.com',
+            'phoneNumber' => '3311111111111',
             'nationalityId' => 133,
             'wantedPoleId' => 5,
             'outYear' => 2021,

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -770,4 +770,37 @@ class MemberInscriptionIntegrationTest extends AppTestCase
             $this->assertContains('Clark', array($memberInscription->firstName, $memberInscription->lastName, $memberInscription->phoneNumber, $memberInscription->email));
         }
     }
+
+    public function testPostMemberWithoutPhoneNumberInscriptionShouldReturn400()
+    {
+        $post_body = array(
+            'firstName' => 'Thanos',
+            'lastName' => 'Tueur de monde',
+            'genderId' => 4,
+            'birthday' => '1000-01-01',
+            'departmentId' => 4,
+            'email' => 'thanos@claquementdedoigts.com',
+            'outYear' => 6666,
+            'nationalityId' => 133,
+            'wantedPoleId' => 5,
+            'address' => array(
+                'line1' => 'je sais pas quoi mettre',
+                'line2' => "",
+                'city' => 'Lorem ipsum',
+                'postalCode' => 66666,
+                'countryId' => 133,
+            ),
+            'droitImage' => true,
+        );
+
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/api/v1/sg/membre-inscription',
+        ]);
+        $req = Request::createFromEnvironment($env);
+        $req = $req->withParsedBody($post_body);
+        $this->app->getContainer()['request'] = $req;
+        $response = $this->app->run(false);
+        $this->assertSame(400, $response->getStatusCode());
+    }
 }

--- a/tests/Sg/MemberInscriptionIntegrationTest.php
+++ b/tests/Sg/MemberInscriptionIntegrationTest.php
@@ -212,7 +212,7 @@ class MemberInscriptionIntegrationTest extends AppTestCase
         $this->assertSame('1000-01-01', $body->birthday);
         $this->assertSame(4, $body->department->id);
         $this->assertSame('thanos@claquementdedoigts.com', $body->email);
-        $this->assertSame(null, $body->phoneNumber);
+        $this->assertSame('3311111111111', $body->phoneNumber);
         $this->assertSame(2021, $body->outYear);
         $this->assertSame(133, $body->nationality->id);
         $this->assertSame(5, $body->wantedPole->id);


### PR DESCRIPTION
Le numéro de téléphone devient required pour les inscriptions membres.
-> les champs actuellement `null` auront un numéro de téléphone bidon pour pouvoir valider l'inscription
-> doc mise à jour

**=> les tests ne sont pas run par Travis, ne pas merge**