### PR TITLE
Adding ability to use keros from other front-ends

### DIFF
--- a/.deploy/apache.conf
+++ b/.deploy/apache.conf
@@ -2,8 +2,8 @@
     DocumentRoot /var/www/keros-api/src
 
     Alias "/generated" "/var/www/keros-api/documents/tmp"
-
     LogLevel info
     ErrorLog /var/www/keros-api/logs/keros-api.error.log
     CustomLog /var/www/keros-api/logs/keros-api.access.log combined
+    Header set Access-Control-Allow-Origin "*"
 </VirtualHost>

--- a/src/KerosApp.php
+++ b/src/KerosApp.php
@@ -139,6 +139,51 @@ class KerosApp
             ->add(AccessRightsService::class . ":checkRightsNotAlumni")
             ->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
+            // Protected core routes
+            $this->group('/core', function () {
+
+                $this->group('/member', function () {
+                    $this->get("", MemberController::class . ':getPageMembers');
+                    $this->get("/me", MemberController::class . ':getConnectedUser');
+                    $this->put("/me", MemberController::class . ':updateConnectedUser');
+                    $this->get('/{id:[0-9]+}', MemberController::class . ':getMember');
+                    $this->post("", MemberController::class . ':createMember');
+                    $this->put("/{id:[0-9]+}", MemberController::class . ':updateMember');
+                    $this->delete("/{id:[0-9]+}", MemberController::class . ':deleteMember');
+                    $this->get("/board/latest", MemberController::class . ':getLatestBoard');
+                    $this->post("/{id:[0-9]+}/photo", MemberController::class . ':createProfilePicture');
+                    $this->get("/{id:[0-9]+}/photo", MemberController::class . ':getProfilePicture');
+                    $this->post("/me/photo", MemberController::class . ':createCurrentUserProfilePicture');
+                    $this->get("/me/photo", MemberController::class . ':getCurrentUserProfilePicture');
+					$this->delete("/{id:[0-9]+}/photo", MemberController::class . ':deleteProfilePicture');
+					$this->post("/export", MemberController::class . ':exportMembers');
+                });
+
+                $this->group('/consultant', function () {
+                    $this->get("", ConsultantController::class . ':getPageConsultants');
+                    $this->get("/me", ConsultantController::class . ':getConnectedConsultant');
+                    $this->put("/me", ConsultantController::class . ':updateConnectedConsultant');
+                    $this->get('/{id:[0-9]+}', ConsultantController::class . ':getConsultant');
+                    $this->post("", ConsultantController::class . ':createConsultant');
+                    $this->put("/{id:[0-9]+}", ConsultantController::class . ':updateConsultant');
+                    $this->delete("/{id:[0-9]+}", ConsultantController::class . ':deleteConsultant');
+                    $this->get("/{id:[0-9]+}/document/{document_name:[a-zA-Z]+}", ConsultantController::class . ':getDocument');
+                    $this->post("/{id:[0-9]+}/document/{document_name:[a-zA-Z]+}", ConsultantController::class . ':createDocument');
+                    $this->get("/{id:[0-9]+}/protected", ConsultantController::class . ':getConsultantProtectedData');
+                    $this->get("/me/protected", ConsultantController::class . ':getConnectedConsultantProtectedData');
+					$this->post("/export", ConsultantController::class . ':exportConsultants');
+                });
+
+                $this->group('/ticket', function () {
+                    $this->get("", TicketController::class . ':getPageTickets');
+                    $this->get('/{id:[0-9]+}', TicketController::class . ':getTicket');
+                    $this->post("", TicketController::class . ':createTicket');
+                    $this->delete("/{id:[0-9]+}", TicketController::class . ':deleteTicket');
+                });
+
+            })->add($this->getContainer()->get(AuthenticationMiddleware::class));
+
+            // Public core routes
             $this->group('/core', function () {
 
                 $this->group('/department', function () {
@@ -165,45 +210,6 @@ class KerosApp
                     $this->get("", PositionController::class . ':getAllPositions');
                     $this->get("/{id:[0-9]+}", PositionController::class . ':getPosition');
                 });
-
-                $this->group('/member', function () {
-                    $this->get("", MemberController::class . ':getPageMembers');
-                    $this->get("/me", MemberController::class . ':getConnectedUser');
-                    $this->put("/me", MemberController::class . ':updateConnectedUser');
-                    $this->get('/{id:[0-9]+}', MemberController::class . ':getMember');
-                    $this->post("", MemberController::class . ':createMember');
-                    $this->put("/{id:[0-9]+}", MemberController::class . ':updateMember');
-                    $this->delete("/{id:[0-9]+}", MemberController::class . ':deleteMember');
-                    $this->get("/board/latest", MemberController::class . ':getLatestBoard');
-                    $this->post("/{id:[0-9]+}/photo", MemberController::class . ':createProfilePicture');
-                    $this->get("/{id:[0-9]+}/photo", MemberController::class . ':getProfilePicture');
-                    $this->post("/me/photo", MemberController::class . ':createCurrentUserProfilePicture');
-                    $this->get("/me/photo", MemberController::class . ':getCurrentUserProfilePicture');
-					$this->delete("/{id:[0-9]+}/photo", MemberController::class . ':deleteProfilePicture');
-					$this->post("/export", MemberController::class . ':exportMembers');
-                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
-
-                $this->group('/consultant', function () {
-                    $this->get("", ConsultantController::class . ':getPageConsultants');
-                    $this->get("/me", ConsultantController::class . ':getConnectedConsultant');
-                    $this->put("/me", ConsultantController::class . ':updateConnectedConsultant');
-                    $this->get('/{id:[0-9]+}', ConsultantController::class . ':getConsultant');
-                    $this->post("", ConsultantController::class . ':createConsultant');
-                    $this->put("/{id:[0-9]+}", ConsultantController::class . ':updateConsultant');
-                    $this->delete("/{id:[0-9]+}", ConsultantController::class . ':deleteConsultant');
-                    $this->get("/{id:[0-9]+}/document/{document_name:[a-zA-Z]+}", ConsultantController::class . ':getDocument');
-                    $this->post("/{id:[0-9]+}/document/{document_name:[a-zA-Z]+}", ConsultantController::class . ':createDocument');
-                    $this->get("/{id:[0-9]+}/protected", ConsultantController::class . ':getConsultantProtectedData');
-                    $this->get("/me/protected", ConsultantController::class . ':getConnectedConsultantProtectedData');
-					$this->post("/export", ConsultantController::class . ':exportConsultants');
-                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
-
-                $this->group('/ticket', function () {
-                    $this->get("", TicketController::class . ':getPageTickets');
-                    $this->get('/{id:[0-9]+}', TicketController::class . ':getTicket');
-                    $this->post("", TicketController::class . ':createTicket');
-                    $this->delete("/{id:[0-9]+}", TicketController::class . ':deleteTicket');
-                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
             });
 

--- a/src/KerosApp.php
+++ b/src/KerosApp.php
@@ -180,7 +180,6 @@ class KerosApp
                     $this->post("", TicketController::class . ':createTicket');
                     $this->delete("/{id:[0-9]+}", TicketController::class . ':deleteTicket');
                 });
-
             })->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
             // Public core routes
@@ -210,7 +209,6 @@ class KerosApp
                     $this->get("", PositionController::class . ':getAllPositions');
                     $this->get("/{id:[0-9]+}", PositionController::class . ':getPosition');
                 });
-
             });
 
             $this->post("/core/member/paid", MemberController::class. ':updatePaymentDate');
@@ -243,10 +241,10 @@ class KerosApp
             ->add(AccessRightsService::class . ":checkRightsNotAlumni")
             ->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
+            // Protected sg routes
             $this->group('/sg', function () {
                 $this->group('/membre-inscription', function () {
                     $this->get("", MemberInscriptionController::class . ':getPageMemberInscriptions');
-                    $this->post("", MemberInscriptionController::class . ':createMemberInscription');
                     $this->get('/{id:[0-9]+}', MemberInscriptionController::class . ':getMemberInscription');
                     $this->delete("/{id:[0-9]+}", MemberInscriptionController::class . ':deleteMemberInscription');
                     $this->put("/{id:[0-9]+}", MemberInscriptionController::class . ':updateMemberInscription');
@@ -258,7 +256,6 @@ class KerosApp
                 });
                 $this->group('/consultant-inscription', function () {
                     $this->get("", ConsultantInscriptionController::class . ':getPageConsultantInscriptions');
-                    $this->post("", ConsultantInscriptionController::class . ':createConsultantInscription');
                     $this->get('/{id:[0-9]+}', ConsultantInscriptionController::class . ':getConsultantInscription');
                     $this->get('/{id:[0-9]+}/protected', ConsultantInscriptionController::class.':getConsultantInscriptionProtected');
                     $this->delete("/{id:[0-9]+}", ConsultantInscriptionController::class . ':deleteConsultantInscription');
@@ -270,6 +267,16 @@ class KerosApp
             })
             ->add(AccessRightsService::class . ":checkRightsNotAlumni")
             ->add($this->getContainer()->get(AuthenticationMiddleware::class));
+
+            // Public sg routes
+            $this->group('/sg', function () {
+                $this->group('/membre-inscription', function () {
+                    $this->post("", MemberInscriptionController::class . ':createMemberInscription');
+                });
+                $this->group('/consultant-inscription', function () {
+                    $this->post("", ConsultantInscriptionController::class . ':createConsultantInscription');
+                });
+            });
         });
 
         $this->app = $app;

--- a/src/KerosApp.php
+++ b/src/KerosApp.php
@@ -181,7 +181,7 @@ class KerosApp
                     $this->get("/me/photo", MemberController::class . ':getCurrentUserProfilePicture');
 					$this->delete("/{id:[0-9]+}/photo", MemberController::class . ':deleteProfilePicture');
 					$this->post("/export", MemberController::class . ':exportMembers');
-                });
+                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
                 $this->group('/consultant', function () {
                     $this->get("", ConsultantController::class . ':getPageConsultants');
@@ -196,16 +196,16 @@ class KerosApp
                     $this->get("/{id:[0-9]+}/protected", ConsultantController::class . ':getConsultantProtectedData');
                     $this->get("/me/protected", ConsultantController::class . ':getConnectedConsultantProtectedData');
 					$this->post("/export", ConsultantController::class . ':exportConsultants');
-                });
+                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
                 $this->group('/ticket', function () {
                     $this->get("", TicketController::class . ':getPageTickets');
                     $this->get('/{id:[0-9]+}', TicketController::class . ':getTicket');
                     $this->post("", TicketController::class . ':createTicket');
                     $this->delete("/{id:[0-9]+}", TicketController::class . ':deleteTicket');
-                });
+                })->add($this->getContainer()->get(AuthenticationMiddleware::class));
 
-            })->add($this->getContainer()->get(AuthenticationMiddleware::class));
+            });
 
             $this->post("/core/member/paid", MemberController::class. ':updatePaymentDate');
 


### PR DESCRIPTION
Added CORS authorization to enable cross-origin requests without having to pass through a proxy.
Removed authentication from some non-confidential core routes (departments/poles etc) and consultant/member inscriptions.
These modifications are mainly to enable the site d'inscription to directly use keros-back without passing through a proxy back-end.