### PR TITLE
Enable header component in apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /var/www
 COPY . ./keros-api
 
 RUN a2enmod rewrite \
+    ## Enable apache headers
+    && a2enmod headers \
     # General preparation
     && apt-get update \
     && apt-get install git zip unzip pdftk libzip-dev -yq \


### PR DESCRIPTION
Fix to enable headers in apache.
Otherwise the `Header` line in the `apache.conf` file will cause the application server to fail